### PR TITLE
Do not ask for the Next version

### DIFF
--- a/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
@@ -40,6 +40,7 @@ trait AllSettings
     with fileValidation
     with enforcement
     with bash
+    with release
     with utils {
 
   /**
@@ -72,7 +73,7 @@ trait AllSettings
   lazy val sharedReleaseProcess = Seq(
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
-      inquireVersions,
+      orgInquireVersions,
       runClean,
       runTest,
       setReleaseVersion,
@@ -82,7 +83,7 @@ trait AllSettings
       setNextVersion,
       commitNextVersion,
       ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
-      pushChanges
+      orgPushChanges
     )
   )
 

--- a/src/main/scala/sbtorgpolicies/settings/bash.scala
+++ b/src/main/scala/sbtorgpolicies/settings/bash.scala
@@ -37,12 +37,33 @@ trait bash extends bashKeys with filesKeys with keys {
     orgCommitMessageSetting := "Updates policy files from SBT",
     orgPublishRelease := Def.taskDyn {
 
-      val buildVersion = (version in ThisBuild).value
-      val exitCode     = if (!buildVersion.endsWith("-SNAPSHOT")) "sbt release".! else 0
+      val buildV       = (version in ThisBuild).value
+      val scalaV       = scalaVersion.value
+      val crossV       = crossScalaVersions.value
+      val isSnapshotV  = buildV.endsWith("-SNAPSHOT")
+      val isLastScalaV = crossV.lastOption.exists(_ == scalaV)
 
-      if (exitCode == 0) Def.task(publishSigned.value)
-      else Def.task()
+      streams.value.log.info(s"""orgPublishRelease Initiated
+           |Build Version = $buildV
+           |Scala Version = $scalaV
+           |crossScalaVersions = $crossV
+           |isSnapshotV = $isSnapshotV
+           |isLastScalaV = $isLastScalaV
+         """.stripMargin)
 
+      (isSnapshotV, isLastScalaV) match {
+        case (true, _) =>
+          streams.value.log.info("SNAPSHOT version detected, skipping release and publishing it...")
+          Def.task(publishSigned.value)
+        case (false, true) =>
+          streams.value.log.info("Release Version detected, starting the release process...")
+          s"git checkout ${orgCommitBranchSetting.value}".!
+          "sbt release".!
+          Def.task()
+        case _ =>
+          streams.value.log.info(s"Release Version detected but it'll be skipped for Scala $scalaV...")
+          Def.task()
+      }
     }.value
   )
 

--- a/src/main/scala/sbtorgpolicies/settings/release.scala
+++ b/src/main/scala/sbtorgpolicies/settings/release.scala
@@ -1,0 +1,62 @@
+package sbtorgpolicies.settings
+
+import sbt.Keys.version
+import sbt.{ProcessLogger, Project, SimpleReader, State}
+import sbtrelease.ReleasePlugin.autoImport.ReleaseKeys._
+import sbtrelease.ReleasePlugin.autoImport._
+import sbtrelease.{Git, Utilities, Vcs}
+
+trait release {
+  import Utilities._
+
+  private def vcs(st: State): Vcs =
+    st.extract
+      .get(releaseVcs)
+      .getOrElse(sys.error("Aborting release. Working directory is not a repository of a recognized VCS."))
+
+  lazy val orgInquireVersions: ReleaseStep = { st: State =>
+    val extracted = Project.extract(st)
+
+    val useDefs  = st.get(useDefaults).getOrElse(false)
+    val releaseV = extracted.get(version)
+
+    val nextFunc = extracted.get(releaseNextVersion)
+    val nextV    = nextFunc(releaseV)
+
+    st.put(versions, (releaseV, nextV))
+  }
+
+  lazy val orgPushChanges: ReleaseStep = ReleaseStep(orgPushChangesAction, orgCheckUpstream)
+
+  private[this] lazy val orgPushChangesAction = { st: State =>
+    val vc = vcs(st)
+    if (vc.hasUpstream) {
+      val processLogger: ProcessLogger = if (vc.isInstanceOf[Git]) {
+        vc.stdErrorToStdOut(st.log)
+      } else st.log
+      vc.pushChanges !! processLogger
+    } else {
+      st.log.info("Changes were NOT pushed, because no upstream branch is configured for the local branch [%s]" format vcs(
+        st).currentBranch)
+    }
+    st
+  }
+
+  private[this] lazy val orgCheckUpstream = { st: State =>
+    if (!vcs(st).hasUpstream) {
+      sys.error(
+        "No tracking branch is set up. Either configure a remote tracking branch, or remove the pushChanges release part.")
+    }
+
+    st.log.info("Checking remote [%s] ..." format vcs(st).trackingRemote)
+    if (vcs(st).checkRemote(vcs(st).trackingRemote) ! st.log != 0) {
+      sys.error("Aborting the release!")
+    }
+
+    if (vcs(st).isBehindRemote) {
+      sys.error("Merge the upstream commits and run `release` again.")
+    }
+    st
+  }
+
+}


### PR DESCRIPTION
This PR allows to do not ask for the next version, just use the specified in the version.sbt. From now on, by the same token, the release process won't ask when pushing changes to Github either. However, some changes are still needed to use the GitHub token instead of the ssh keys.