### PR TITLE
Tag Release using github4s

### DIFF
--- a/core/src/main/scala/sbtorgpolicies/github/syntax.scala
+++ b/core/src/main/scala/sbtorgpolicies/github/syntax.scala
@@ -1,0 +1,39 @@
+package sbtorgpolicies.github
+
+import cats.data.EitherT
+import github4s.Github._
+import github4s.jvm.Implicits._
+import github4s.GithubResponses.{GHException, GHIO, GHResponse, GHResult}
+import sbtorgpolicies.exceptions.GitHubException
+import sbtorgpolicies.github.instances._
+
+import scala.util.{Failure, Success, Try}
+import scalaj.http.HttpResponse
+
+object syntax {
+
+  private[this] val commonHeaders = Map("user-agent" -> "sbt-org-policies")
+
+  implicit class EitherTOps[R](eitherT: EitherT[GHIO, GHException, GHResult[R]]) {
+
+    def execE: Either[GitHubException, R] = eitherT.value.execE
+
+  }
+
+  implicit class GHIOOps[R](ghIO: GHIO[Either[GHException, GHResult[R]]]) {
+
+    def execE: Either[GitHubException, R] =
+      ghIO.exec[Try, HttpResponse[String]](commonHeaders).toEither
+
+  }
+
+  implicit class GHResponseTrySyntax[R](m: Try[GHResponse[R]]) {
+
+    def toEither: Either[GitHubException, R] = m match {
+      case Success(Right(r)) => Right(r.result)
+      case Success(Left(e))  => Left(GitHubException(s"GitHub returned an error: ${e.getMessage}", Some(e)))
+      case Failure(e)        => Left(GitHubException("Error making request to GitHub", Some(e)))
+    }
+
+  }
+}

--- a/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
@@ -78,7 +78,7 @@ trait AllSettings
       runTest,
       setReleaseVersion,
       commitReleaseVersion,
-      tagRelease,
+      orgTagRelease,
       publishArtifacts,
       setNextVersion,
       commitNextVersion,

--- a/src/main/scala/sbtorgpolicies/settings/DefaultSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/DefaultSettings.scala
@@ -21,6 +21,7 @@ import de.heikoseeberger.sbtheader.HeaderKey.headers
 import de.heikoseeberger.sbtheader.license.Apache2_0
 import sbt._
 import sbt.Keys._
+import sbtorgpolicies.github.GitHubOps
 import sbtorgpolicies.model._
 
 trait DefaultSettings extends AllSettings {
@@ -36,6 +37,10 @@ trait DefaultSettings extends AllSettings {
         organizationEmail = "hello@47deg.com"
       ),
       orgGithubTokenSetting := None,
+      orgGithubOps := new GitHubOps(
+        orgGithubSetting.value.organization,
+        orgGithubSetting.value.project,
+        orgGithubTokenSetting.value),
       orgLicenseSetting := ApacheLicense,
       orgMaintainersSetting := List(Dev("47degdev", Some("47 Degrees (twitter: @47deg)"), Some("hello@47deg.com"))),
       orgContributorsSetting := Nil,

--- a/src/main/scala/sbtorgpolicies/settings/bash.scala
+++ b/src/main/scala/sbtorgpolicies/settings/bash.scala
@@ -80,10 +80,7 @@ trait bash extends bashKeys with filesKeys with keys {
   val orgBashTasks =
     Seq(
       orgCommitPolicyFiles := Def.task {
-        val ghOps = new GitHubOps(
-          orgGithubSetting.value.organization,
-          orgGithubSetting.value.project,
-          orgGithubTokenSetting.value)
+        val ghOps: GitHubOps = orgGithubOps.value
         (for {
           filesAndContents <- readFileContents(orgEnforcedFiles.value)
           _ <- ghOps.commitFiles(

--- a/src/main/scala/sbtorgpolicies/settings/files.scala
+++ b/src/main/scala/sbtorgpolicies/settings/files.scala
@@ -70,11 +70,8 @@ trait files extends filesKeys with templatesKeys with keys {
 
       }.value,
       orgCreateContributorsFile := Def.task {
-        val fh = new FileHelper
-        val ghOps = new GitHubOps(
-          orgGithubSetting.value.organization,
-          orgGithubSetting.value.project,
-          orgGithubTokenSetting.value)
+        val fh    = new FileHelper
+        val ghOps = orgGithubOps.value
 
         (for {
           list <- ghOps.fetchContributors

--- a/src/main/scala/sbtorgpolicies/settings/keys.scala
+++ b/src/main/scala/sbtorgpolicies/settings/keys.scala
@@ -17,6 +17,7 @@
 package sbtorgpolicies.settings
 
 import sbt._
+import sbtorgpolicies.github.GitHubOps
 import sbtorgpolicies.model._
 
 trait keys {
@@ -26,6 +27,9 @@ trait keys {
 
   val orgGithubTokenSetting: SettingKey[Option[String]] =
     settingKey[Option[String]]("Github token, needed to be used to interact with Github, empty by default")
+
+  val orgGithubOps: SettingKey[GitHubOps] =
+    settingKey[GitHubOps]("Github wrapper to interact with github4s and the Github API")
 
   val orgLicenseSetting: SettingKey[License] =
     settingKey[License]("General Org License Setting")


### PR DESCRIPTION
This PR brings a new `ReleaseStep` (`orgTagRelease`) that allows to release the version using github4s.

Please, @fedefernandez could you review? Thanks!