### PR TITLE
Turns orgPublishRelease into a sbt command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ cache:
   - $HOME/.ivy2/cache
   - $HOME/.sbt/boot/
 before_install:
-- openssl aes-256-cbc -K $encrypted_7c61f7d7bb76_key -iv $encrypted_7c61f7d7bb76_iv
-  -in secring.gpg.enc -out secring.gpg -d
+- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    openssl aes-256-cbc -K $encrypted_7c61f7d7bb76_key -iv $encrypted_7c61f7d7bb76_iv
+    -in secring.gpg.enc -out secring.gpg -d;
+  fi
 - rm -rf $HOME/.ivy2/cache/scala_2.10/sbt_0.13/com.47deg/sbt-org-policies
 script:
 - sbt ++$TRAVIS_SCALA_VERSION clean compile test

--- a/core/src/main/resources/templates/travis.yml.template
+++ b/core/src/main/resources/templates/travis.yml.template
@@ -30,7 +30,6 @@ install:
 - gem update --system
 - gem install sass
 - gem install jekyll -v 3.4.3
-- pip install --user codecov
 
 script:
 - sbt ++$TRAVIS_SCALA_VERSION orgValidateFiles
@@ -40,4 +39,4 @@ script:
 
 after_success:
 - sbt ++$TRAVIS_SCALA_VERSION orgAfterCISuccess
-- codecov
+- bash <(curl -s https://codecov.io/bash) -t token_replace-me

--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -21,9 +21,10 @@ object libraries {
   type Artifact = (String, String, String)
 
   val v47: Map[String, String] = Map[String, String](
-    "case-classy" -> "0.3.0",
-    "fetch"       -> "0.6.0",
-    "github4s"    -> "0.14.2"
+    "case-classy"           -> "0.3.0",
+    "fetch"                 -> "0.6.0",
+    "github4s"              -> "0.14.2",
+    "scheckToolboxDatetime" -> "0.2.1"
   )
 
   protected val vOthers: Map[String, String] = Map[String, String](
@@ -201,6 +202,7 @@ object libraries {
     "roshttp"                -> (("fr.hmil", "roshttp", v("roshttp"))),
     "scalacheck"             -> (("org.scalacheck", "scalacheck", v("scalacheck"))),
     "scheckShapeless"        -> (("com.github.alexarchambault", "scalacheck-shapeless_1.13", v("scheckShapeless"))),
+    "scheckToolboxDatetime"  -> (("com.fortysevendeg", "scalacheck-toolbox-datetime", v("scheckToolboxDatetime"))),
     "scalaj"                 -> (("org.scalaj", "scalaj-http", v("scalaj"))),
     "scalatest"              -> (("org.scalatest", "scalatest", v("scalatest"))),
     "scalaz-concurrent"      -> (("org.scalaz", "scalaz-concurrent", v("scalaz"))),

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -33,7 +33,7 @@ object ProjectPlugin extends AutoPlugin {
       addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"          % "0.6.1"),
       addSbtPlugin("com.geirsson"       % "sbt-scalafmt"           % "0.6.8"),
       addSbtPlugin("com.47deg"          % "sbt-dependencies"       % "0.1.0"),
-      addSbtPlugin("com.47deg"          % "sbt-microsites"         % "0.5.1")
+      addSbtPlugin("com.47deg"          % "sbt-microsites"         % "0.5.3")
     ) ++
       ScriptedPlugin.scriptedSettings ++ Seq(
       scriptedDependencies := (compile in Test) map { _ =>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.13
+sbt.version = 0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
-resolvers += Resolver.sonatypeRepo("snapshots")
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.6-SNAPSHOT")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.6")
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/src/main/scala/sbtorgpolicies/OrgPoliciesKeys.scala
+++ b/src/main/scala/sbtorgpolicies/OrgPoliciesKeys.scala
@@ -94,7 +94,7 @@ sealed trait OrgPoliciesTaskKeys {
 
   val orgFetchContributors: TaskKey[List[Dev]] = taskKey[List[Dev]]("Task to fetch the project's contributors.")
 
-  val orgPublishRelease: TaskKey[Unit] = taskKey[Unit](
+  val orgPublishReleaseTask: TaskKey[Unit] = taskKey[Unit](
     "This task allows to publish the artifact (publishSigned) in case of dealing with an snapshot, or, " +
       "releasing a new version in any other case.")
 
@@ -108,6 +108,8 @@ sealed trait OrgPoliciesTaskKeys {
 
 sealed trait CommandKeys {
 
-  val afterCISuccessCommandKey = "orgAfterCISuccess"
+  val orgAfterCISuccessCommandKey = "orgAfterCISuccess"
+
+  val orgPublishReleaseCommandKey = "orgPublishRelease"
 
 }

--- a/src/main/scala/sbtorgpolicies/settings/DefaultSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/DefaultSettings.scala
@@ -83,7 +83,7 @@ trait DefaultSettings extends AllSettings {
       TravisFileType(crossScalaVersions.value)
     ),
     orgTemplatesDirectorySetting := (resourceDirectory in Compile).value / "org" / "templates",
-    commands += orgAfterCISuccessCommand,
+    commands ++= Seq(orgPublishReleaseCommand, orgAfterCISuccessCommand),
     orgAfterCISuccessCheckSetting := {
       getEnvVarOrElse("TRAVIS_BRANCH") == orgCommitBranchSetting.value &&
       getEnvVarOrElse("TRAVIS_PULL_REQUEST") == "false"
@@ -92,7 +92,7 @@ trait DefaultSettings extends AllSettings {
       orgCreateFiles.toOrgTask,
       orgCommitPolicyFiles.toOrgTask,
       depUpdateDependencyIssues.toOrgTask,
-      orgPublishRelease.toOrgTask(allModulesScope = true, crossScalaVersionsScope = true)
+      orgPublishReleaseTask.toOrgTask(allModulesScope = true, crossScalaVersionsScope = true)
     )
   )
 }

--- a/src/main/scala/sbtorgpolicies/settings/bash.scala
+++ b/src/main/scala/sbtorgpolicies/settings/bash.scala
@@ -48,7 +48,8 @@ trait bash {
         }
       }.value,
       orgPublishReleaseTask := Def.task {
-        s"sbt $orgPublishReleaseCommandKey".!
+        val scalaV = scalaVersion.value
+        s"sbt ++$scalaV $orgPublishReleaseCommandKey".!
         (): Unit
       }.value
     )

--- a/src/sbt-test/sbtorgpolicies/valid-files/.travis.yml
+++ b/src/sbt-test/sbtorgpolicies/valid-files/.travis.yml
@@ -42,4 +42,4 @@ script:
 
 after_success:
 - sbt ++$TRAVIS_SCALA_VERSION orgAfterCISuccess
-- codecov
+- bash <(curl -s https://codecov.io/bash) -t token_replace-me

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.7-SNAPSHOT"
+version in ThisBuild := "0.4.7"


### PR DESCRIPTION
Fixes https://github.com/47deg/sbt-org-policies/issues/141

It also:

* Adds scalacheck-toolbox-datetime to the library catalogue
* Changes the travis.yml template in order to use the codecov reports upload based on a bash command
* Bumps sbt-microsites version
* Bumps sbt version -> `0.13.15`

Please, @fedefernandez have a look when you have a chance. Thanks.
