### PR TITLE
SOP-138 Fixes Enforcement Tasks

### DIFF
--- a/core/src/main/resources/templates/travis.yml.template
+++ b/core/src/main/resources/templates/travis.yml.template
@@ -32,9 +32,7 @@ install:
 - gem install jekyll -v 3.4.3
 
 script:
-- sbt ++$TRAVIS_SCALA_VERSION orgValidateFiles
-- sbt ++$TRAVIS_SCALA_VERSION orgCheckSettings
-- sbt ++$TRAVIS_SCALA_VERSION clean coverage compile test coverageReport
+- sbt ++$TRAVIS_SCALA_VERSION orgScriptCI
 - sbt ++$TRAVIS_SCALA_VERSION tut
 
 after_success:

--- a/core/src/main/scala/sbtorgpolicies/model.scala
+++ b/core/src/main/scala/sbtorgpolicies/model.scala
@@ -118,17 +118,17 @@ object model {
       </developer>
   }
 
-  case class AfterSuccessTask(
+  case class RunnableCITask(
       task: TaskKey[Unit],
       allModulesScope: Boolean = false,
       crossScalaVersionsScope: Boolean = false)
 
   implicit class AfterSuccessTaskOps(taskKey: TaskKey[Unit]) {
 
-    def toOrgTask: AfterSuccessTask = toOrgTask(allModulesScope = false, crossScalaVersionsScope = false)
+    def toOrgTask: RunnableCITask = toOrgTask(allModulesScope = false, crossScalaVersionsScope = false)
 
-    def toOrgTask(allModulesScope: Boolean, crossScalaVersionsScope: Boolean): AfterSuccessTask =
-      AfterSuccessTask(taskKey, allModulesScope, crossScalaVersionsScope)
+    def toOrgTask(allModulesScope: Boolean, crossScalaVersionsScope: Boolean): RunnableCITask =
+      RunnableCITask(taskKey, allModulesScope, crossScalaVersionsScope)
 
   }
 

--- a/src/main/scala/sbtorgpolicies/OrgPoliciesKeys.scala
+++ b/src/main/scala/sbtorgpolicies/OrgPoliciesKeys.scala
@@ -73,7 +73,7 @@ sealed trait OrgPoliciesSettingsKeys {
   val orgScriptTaskListSetting: SettingKey[List[RunnableCITask]] =
     settingKey[List[RunnableCITask]](
       "Defines the list of tasks that should be executed to figure out whether the build is correct. " +
-        "By default, it'be something like this: 'sbt clean coverage compile test coverageReport'")
+        "By default, it'd be something like this: 'sbt clean coverage compile test coverageReport'")
 
   val orgTargetDirectorySetting: SettingKey[File] =
     SettingKey[File]("orgTargetDirectory", "Where sbt-org-policies output goes.")

--- a/src/main/scala/sbtorgpolicies/OrgPoliciesKeys.scala
+++ b/src/main/scala/sbtorgpolicies/OrgPoliciesKeys.scala
@@ -35,8 +35,8 @@ sealed trait OrgPoliciesSettingsKeys {
     settingKey[Boolean](
       "Defines the condition that the orgAfterCISuccess command will check before running the orgAfterCISuccessTaskListSetting list.")
 
-  val orgAfterCISuccessTaskListSetting: SettingKey[List[AfterSuccessTask]] =
-    settingKey[List[AfterSuccessTask]](
+  val orgAfterCISuccessTaskListSetting: SettingKey[List[RunnableCITask]] =
+    settingKey[List[RunnableCITask]](
       "Defines the list of tasks that should be executed once the Continuous integration build has finished successfully.")
 
   val orgBadgeListSetting: SettingKey[List[BadgeBuilder]] =
@@ -70,6 +70,11 @@ sealed trait OrgPoliciesSettingsKeys {
   val orgMaintainersSetting: SettingKey[List[Dev]] =
     settingKey[List[Dev]]("List of Maintainers of the project.")
 
+  val orgScriptTaskListSetting: SettingKey[List[RunnableCITask]] =
+    settingKey[List[RunnableCITask]](
+      "Defines the list of tasks that should be executed to figure out whether the build is correct. " +
+        "By default, it'be something like this: 'sbt clean coverage compile test coverageReport'")
+
   val orgTargetDirectorySetting: SettingKey[File] =
     SettingKey[File]("orgTargetDirectory", "Where sbt-org-policies output goes.")
 
@@ -93,6 +98,9 @@ sealed trait OrgPoliciesTaskKeys {
 
   val orgCommitPolicyFiles: TaskKey[Unit] = taskKey[Unit]("Commits the policy files into the specified branch.")
 
+  val orgCompile: TaskKey[Unit] =
+    taskKey[Unit]("Just a (compile in Compile) but ignoring the result (Analysis type) and returning Unit.")
+
   val orgCreateFiles: TaskKey[Unit] =
     taskKey[Unit]("Task to create the files that must exists in a project to accomplish the Organization's policies.")
 
@@ -115,5 +123,7 @@ sealed trait CommandKeys {
   val orgAfterCISuccessCommandKey = "orgAfterCISuccess"
 
   val orgPublishReleaseCommandKey = "orgPublishRelease"
+
+  val orgScriptCICommandKey = "orgScriptCI"
 
 }

--- a/src/main/scala/sbtorgpolicies/settings/DefaultSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/DefaultSettings.scala
@@ -20,6 +20,7 @@ import de.heikoseeberger.sbtheader.AutomateHeaderPlugin
 import de.heikoseeberger.sbtheader.HeaderKey.headers
 import de.heikoseeberger.sbtheader.license.Apache2_0
 import dependencies.DependenciesPlugin.autoImport._
+import scoverage.ScoverageKeys
 import sbt.Keys._
 import sbt._
 import sbtorgpolicies.github.GitHubOps
@@ -99,7 +100,7 @@ trait DefaultSettings extends AllSettings {
       TravisFileType(crossScalaVersions.value)
     ),
     orgTemplatesDirectorySetting := (resourceDirectory in Compile).value / "org" / "templates",
-    commands ++= Seq(orgPublishReleaseCommand, orgAfterCISuccessCommand),
+    commands ++= Seq(orgScriptCICommand, orgPublishReleaseCommand, orgAfterCISuccessCommand),
     orgAfterCISuccessCheckSetting := {
       getEnvVarOrElse("TRAVIS_BRANCH") == orgCommitBranchSetting.value &&
       getEnvVarOrElse("TRAVIS_PULL_REQUEST") == "false"
@@ -109,6 +110,14 @@ trait DefaultSettings extends AllSettings {
       orgCommitPolicyFiles.toOrgTask,
       depUpdateDependencyIssues.toOrgTask,
       orgPublishReleaseTask.toOrgTask(allModulesScope = true, crossScalaVersionsScope = true)
+    ),
+    orgScriptTaskListSetting := List(
+      orgValidateFiles.toOrgTask,
+      orgCheckSettings.toOrgTask,
+      clean.toOrgTask(allModulesScope = true, crossScalaVersionsScope = true),
+      (orgCompile in ThisBuild).toOrgTask(allModulesScope = true, crossScalaVersionsScope = true),
+      (test in Test).toOrgTask(allModulesScope = true, crossScalaVersionsScope = true),
+      ScoverageKeys.coverageReport.toOrgTask
     )
   )
 }

--- a/src/main/scala/sbtorgpolicies/settings/DefaultSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/DefaultSettings.scala
@@ -114,7 +114,6 @@ trait DefaultSettings extends AllSettings {
     orgScriptTaskListSetting := List(
       orgValidateFiles.toOrgTask,
       orgCheckSettings.toOrgTask,
-      clean.toOrgTask(allModulesScope = true, crossScalaVersionsScope = true),
       (orgCompile in ThisBuild).toOrgTask(allModulesScope = true, crossScalaVersionsScope = true),
       (test in Test).toOrgTask(allModulesScope = true, crossScalaVersionsScope = true),
       ScoverageKeys.coverageReport.toOrgTask

--- a/src/main/scala/sbtorgpolicies/settings/bash.scala
+++ b/src/main/scala/sbtorgpolicies/settings/bash.scala
@@ -173,8 +173,6 @@ trait bash {
       newState.log.info(s"[$commandName] Initiating with this set of tasks: ${toStringListTask(executableTasks)}")
 
       executableTasks.foldLeft(newState) { (st, task) =>
-        st.log.info(s"Running task ${task.key} with scope ${task.scope.toString}")
-
         Project.extract(st).runTask(task, st)._1
       }
     } else {

--- a/src/main/scala/sbtorgpolicies/settings/bash.scala
+++ b/src/main/scala/sbtorgpolicies/settings/bash.scala
@@ -22,9 +22,10 @@ import sbt._
 import sbt.complete.DefaultParsers.OptNotSpace
 import sbtorgpolicies.OrgPoliciesKeys._
 import sbtorgpolicies.github.GitHubOps
-import sbtorgpolicies.model.Dev
+import sbtorgpolicies.model.{Dev, RunnableCITask}
 import sbtorgpolicies.utils._
 import sbtrelease.ReleaseStateTransformations.reapply
+import scoverage.ScoverageKeys
 
 trait bash {
 
@@ -96,50 +97,88 @@ trait bash {
     finalState
   }
 
+  val orgScriptCICommand: Command = Command(orgScriptCICommandKey)(_ => OptNotSpace) { (st, _) =>
+    runTaskListCommand("orgScriptCI", orgScriptTaskListSetting, st)
+  }
+
   val orgAfterCISuccessCommand: Command = Command(orgAfterCISuccessCommandKey)(_ => OptNotSpace) { (st, _) =>
     val extracted = Project.extract(st)
 
-    val afterSuccessCheck = extracted.get(orgAfterCISuccessCheckSetting)
+    if (extracted.get(orgAfterCISuccessCheckSetting)) {
 
-    if (afterSuccessCheck) {
-
-      val scalaV      = extracted.get(scalaVersion)
-      val crossV      = extracted.get(crossScalaVersions)
-      val baseDir     = extracted.get(baseDirectory)
-      val envVarToken = extracted.get(orgGithubTokenSetting)
-      val maybeToken  = getEnvVar(envVarToken)
-      val rootDir     = extracted.get(baseDirectory in LocalRootProject)
-
-      val isLastScalaV = crossV.lastOption.exists(_ == scalaV)
-      val isRootModule = baseDir.getAbsolutePath == rootDir.getAbsolutePath
-      val taskList     = extracted.get(orgAfterCISuccessTaskListSetting)
-
-      val executableTasks = taskList.filter { tsk =>
-        (isLastScalaV || tsk.crossScalaVersionsScope) &&
-        (isRootModule || tsk.allModulesScope)
-      } map (_.task)
-
-      if (executableTasks.nonEmpty) {
-
-        st.log.info(
-          s"[orgAfterCISuccess] Initiating orgAfterCISuccessCommand " +
-            s"with this set of tasks: ${toStringListTask(executableTasks)}")
+      val beforeTasksState = (st: State) => {
+        val envVarToken = extracted.get(orgGithubTokenSetting)
+        val maybeToken  = getEnvVar(envVarToken)
 
         val (fetchContributorsState, contributorList) =
           if (maybeToken.nonEmpty) {
             extracted.runTask[List[Dev]](orgFetchContributors, st)
           } else (st, Nil)
 
-        val newState = reapply(Seq[Setting[_]](orgContributorsSetting := contributorList), fetchContributorsState)
-
-        executableTasks map (Project.extract(newState).runTask(_, newState))
-        newState
-      } else {
-        st.log.info("[orgAfterCISuccess] No tasks to execute")
-        st
+        reapply(Seq[Setting[_]](orgContributorsSetting := contributorList), fetchContributorsState)
       }
+
+      runTaskListCommand(
+        "orgAfterCISuccess",
+        orgAfterCISuccessTaskListSetting,
+        st,
+        beforeTasksState
+      )
+
     } else {
       st.log.info("[orgAfterCISuccess] orgAfterCISuccessCheckSetting is false, skipping tasks after CI success")
+      st
+    }
+  }
+
+  private[this] def runTaskListCommand(
+      commandName: String,
+      taskListSettingKey: SettingKey[List[RunnableCITask]],
+      st: State,
+      stateToState: (State) => State = st => st): State = {
+
+    val extracted = Project.extract(st)
+
+    val scalaV  = extracted.get(scalaVersion)
+    val crossV  = extracted.get(crossScalaVersions)
+    val baseDir = extracted.get(baseDirectory)
+    val rootDir = extracted.get(baseDirectory in LocalRootProject)
+
+    val isLastScalaV = crossV.lastOption.exists(_ == scalaV)
+    val isRootModule = baseDir.getAbsolutePath == rootDir.getAbsolutePath
+
+    val taskList = extracted.get(taskListSettingKey)
+
+    val executableTasks = taskList.filter { tsk =>
+      (isLastScalaV || tsk.crossScalaVersionsScope) &&
+      (isRootModule || tsk.allModulesScope)
+    } map (_.task)
+
+    if (executableTasks.nonEmpty) {
+
+      val stateToStateResult = stateToState(st)
+
+      val newState =
+        if (executableTasks.exists(_.key == ScoverageKeys.coverageReport.key))
+          extracted
+            .runTask(
+              clean,
+              Project
+                .extract(stateToStateResult)
+                .append(Seq(ScoverageKeys.coverageEnabled := true), stateToStateResult))
+            ._1
+        else
+          stateToStateResult
+
+      newState.log.info(s"[$commandName] Initiating with this set of tasks: ${toStringListTask(executableTasks)}")
+
+      executableTasks.foldLeft(newState) { (st, task) =>
+        st.log.info(s"Running task ${task.key} with scope ${task.scope.toString}")
+
+        Project.extract(st).runTask(task, st)._1
+      }
+    } else {
+      st.log.info(s"[$commandName] No tasks to execute")
       st
     }
   }

--- a/src/main/scala/sbtorgpolicies/settings/common.scala
+++ b/src/main/scala/sbtorgpolicies/settings/common.scala
@@ -46,6 +46,11 @@ trait common {
             Nil
         }
       }.value,
-      orgCompile in ThisBuild := Def.task((compile in Compile).map(_ => (): Unit)).value
+      orgCompile in ThisBuild := Def
+        .task[Unit] {
+          compile in Compile
+          (): Unit
+        }
+        .value
     )
 }

--- a/src/main/scala/sbtorgpolicies/settings/common.scala
+++ b/src/main/scala/sbtorgpolicies/settings/common.scala
@@ -45,6 +45,7 @@ trait common {
             e.printStackTrace()
             Nil
         }
-      }.value
+      }.value,
+      orgCompile in ThisBuild := Def.task((compile in Compile).map(_ => (): Unit)).value
     )
 }

--- a/src/main/scala/sbtorgpolicies/settings/fileValidation.scala
+++ b/src/main/scala/sbtorgpolicies/settings/fileValidation.scala
@@ -50,7 +50,7 @@ trait fileValidation extends ValidationFunctions {
         List(
           validTravisFile(
             crossScalaVersions.value,
-            Seq(orgCheckSettings.key.label, orgValidateFiles.key.label),
+            Seq(orgScriptCICommandKey),
             Seq(orgAfterCISuccess.key.label)
           )
         )

--- a/src/sbt-test/sbtorgpolicies/ci-script/README.md
+++ b/src/sbt-test/sbtorgpolicies/ci-script/README.md
@@ -1,0 +1,5 @@
+## README
+
+## sbt-org-policies in the wild
+
+If you wish to add your library here please consider a PR to include it in the list below.

--- a/src/sbt-test/sbtorgpolicies/ci-script/build.sbt
+++ b/src/sbt-test/sbtorgpolicies/ci-script/build.sbt
@@ -1,0 +1,5 @@
+name := "sbt-org-policies"
+
+scalaVersion := "2.12.1"
+
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"

--- a/src/sbt-test/sbtorgpolicies/ci-script/project/plugins.sbt
+++ b/src/sbt-test/sbtorgpolicies/ci-script/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.sonatypeRepo("snapshots")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % sys.props("plugin.version"))

--- a/src/sbt-test/sbtorgpolicies/ci-script/src/main/scala/hw.scala
+++ b/src/sbt-test/sbtorgpolicies/ci-script/src/main/scala/hw.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+object Hi { def main(args: Array[String]) = println("Hi!") }

--- a/src/sbt-test/sbtorgpolicies/ci-script/src/test/scala/hwtest.scala
+++ b/src/sbt-test/sbtorgpolicies/ci-script/src/test/scala/hwtest.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.scalatest.{FunSuite, Matchers}
+
+class hwtest extends FunSuite with Matchers {
+
+  test("hwtest works as expected") {
+
+    Hi.main(Array.empty)
+
+    1 shouldBe 1
+  }
+}

--- a/src/sbt-test/sbtorgpolicies/ci-script/test
+++ b/src/sbt-test/sbtorgpolicies/ci-script/test
@@ -1,0 +1,11 @@
+# checks that the orgScriptCI sbt task works correctly for the default set of tasks
+
+> orgCreateFiles
+
+> orgScriptCI
+
+$ exists target/scala-2.12/coverage-report/cobertura.xml
+
+$ exists target/scala-2.12/scoverage-report/scoverage.xml
+
+$ exists target/scala-2.12/scoverage-report/index.html

--- a/src/sbt-test/sbtorgpolicies/valid-files/.travis.yml
+++ b/src/sbt-test/sbtorgpolicies/valid-files/.travis.yml
@@ -35,9 +35,7 @@ install:
 - pip install --user codecov
 
 script:
-- sbt ++$TRAVIS_SCALA_VERSION orgValidateFiles
-- sbt ++$TRAVIS_SCALA_VERSION orgCheckSettings
-- sbt ++$TRAVIS_SCALA_VERSION clean coverage compile test coverageReport
+- sbt ++$TRAVIS_SCALA_VERSION orgScriptCI
 - sbt ++$TRAVIS_SCALA_VERSION tut
 
 after_success:

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.8-SNAPSHOT"
+version in ThisBuild := "0.4.8"


### PR DESCRIPTION
Fixes https://github.com/47deg/sbt-org-policies/issues/138

This PR brings a new setting key named as `orgScriptTaskListSetting` where the user can specify the list of things that should be run in its CI environment. This list of task will be executed by the command `orgScriptCI`. For example, in the travis case could be something as follows:

```
...
- pip install --user codecov

script:
- sbt ++$TRAVIS_SCALA_VERSION orgScriptCI

after_success:
- sbt ++$TRAVIS_SCALA_VERSION orgAfterCISuccess
...
```

Please, @fedefernandez could you review? Thanks!