### PR TITLE
Method for updating ref with dir contents

### DIFF
--- a/core/src/main/scala/sbtorgpolicies/github/syntax.scala
+++ b/core/src/main/scala/sbtorgpolicies/github/syntax.scala
@@ -62,4 +62,6 @@ object syntax {
       gHResult.copy(result = f(gHResult.result))
 
   }
+
+  def newGHResult[T](v: T): GHResult[T] = GHResult(v, 200, Map.empty)
 }

--- a/core/src/main/scala/sbtorgpolicies/io/FileReader.scala
+++ b/core/src/main/scala/sbtorgpolicies/io/FileReader.scala
@@ -42,6 +42,11 @@ class FileReader {
       .catchNonFatal(IO.readLines(file(filePath)).mkString("\n"))
       .leftMap(e => IOException(s"Error loading $filePath content", Some(e)))
 
+  def getFileBytes(file: File): IOResult[Array[Byte]] =
+    Either
+      .catchNonFatal(IO.readBytes(file))
+      .leftMap(e => IOException(s"Error loading ${file.getAbsolutePath} content", Some(e)))
+
   def fetchFilesRecursivelyFromPath(sourcePath: String, acceptedExtensions: List[String] = Nil): IOResult[List[File]] =
     fetchFilesRecursively(sourcePath.toFile, acceptedExtensions)
 

--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -22,7 +22,7 @@ object libraries {
 
   val v47: Map[String, String] = Map[String, String](
     "case-classy"           -> "0.3.0",
-    "fetch"                 -> "0.6.0",
+    "fetch"                 -> "0.6.1",
     "github4s"              -> "0.14.3",
     "scheckToolboxDatetime" -> "0.2.1"
   )

--- a/core/src/test/scala/sbtorgpolicies/arbitraries/GitHubArbitraries.scala
+++ b/core/src/test/scala/sbtorgpolicies/arbitraries/GitHubArbitraries.scala
@@ -43,7 +43,7 @@ trait GitHubArbitraries {
   val sampleMessage: String      = "Hello World"
   val releaseDescription: String = "Release description"
   val nonExistingMessage: String = "this is a commit message"
-  val baseDir: File              = new File(".")
+  val baseDir: File              = new File("/tmp/")
   val date2015: DateTime         = dateTimeFormat.parseDateTime("2015-01-01T00:00:00.000Z")
   val filesAndContents: List[(String, String)] = 1 to 5 map { index =>
     (s"file$index", s"Content file $index")
@@ -289,6 +289,10 @@ trait GitHubArbitraries {
 
   implicit val ghResponseTreeResultArbitrary: Arbitrary[GHResponse[TreeResult]] = Arbitrary {
     genGHResponse(genTreeResult)
+  }
+
+  implicit val ghResponseRefObjectArbitrary: Arbitrary[GHResponse[RefInfo]] = Arbitrary {
+    genGHResponse(genRefObject)
   }
 
 }


### PR DESCRIPTION
Fixes #231 

Also upgrades `fetch` library

For example, we could commit all the files in folder `docs/target/site` into branch `gh-pages` as follows:

```scala
val dir     = (baseDirectory in LocalRootProject).value / "docs/target/site"
val branch  = "gh-pages"
streams.value.log.info(s"Committing files from ${dir.getAbsolutePath} into branch '$branch'")
val ghOps: GitHubOps = orgGithubOpsSetting.value
ghOps.commitDir(branch, "Commit Message", dir) match {
  case Right(_) => streams.value.log.info("Success")
  case Left(e) =>
    streams.value.log.error(s"Error committing files")
    e.printStackTrace()
}
```

Please @juanpedromoreno, could you review? Thanks