### PR TITLE
Dependencies auto-check Enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ before_install:
 - rm -rf $HOME/.ivy2/cache/scala_2.10/sbt_0.13/com.47deg/sbt-org-policies
 script:
 - sbt ++$TRAVIS_SCALA_VERSION clean compile test
+- sbt ++$TRAVIS_SCALA_VERSION publishLocal;
 - if [ "$TRAVIS_BRANCH" = "master" ]; then
-    sbt ++$TRAVIS_SCALA_VERSION publishLocal;
     sbt ++$TRAVIS_SCALA_VERSION scripted;
   fi
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,4 @@ script:
   fi
 after_success:
 - sbt ++$TRAVIS_SCALA_VERSION orgAfterCISuccess
-- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
-    cd autocheck;
-    sbt -Dplugin.version=$(cat ../version.sbt | sed 's/.*"\(.*\)".*/\1/') depUpdateDependencyIssues;
-  fi
+- cd autocheck && sbt -Dplugin.version=$(cat ../version.sbt | sed 's/.*"\(.*\)".*/\1/') checkDependencies

--- a/autocheck/build.sbt
+++ b/autocheck/build.sbt
@@ -1,7 +1,10 @@
 import sbt.Keys._
 import sbtorgpolicies.OrgPoliciesKeys.orgGithubSetting
+import sbtorgpolicies.io.FileReader
 import sbtorgpolicies.libraries.{javaLibs, scalaLibs}
 import sbtorgpolicies.model.GitHubSettings
+
+lazy val checkDependencies = taskKey[Unit]("Check the module dependencies")
 
 lazy val `org-policies-auto-dep-check` = (project in file("."))
   .settings(name := "org-policies-auto-dep-check")
@@ -21,5 +24,23 @@ lazy val `org-policies-auto-dep-check` = (project in file("."))
     resolvers += Resolver.sonatypeRepo("snapshots"),
     libraryDependencies ++=
       scalaLibs.mapValues(lib => lib._1  %% lib._2 % lib._3).values.toList ++
-        javaLibs.mapValues(lib => lib._1 % lib._2  % lib._3).values.toList
+        javaLibs.mapValues(lib => lib._1 % lib._2  % lib._3).values.toList,
+    checkDependencies := Def.taskDyn {
+      val fr             = new FileReader
+      val versionSbtFile = baseDirectory.value.getParentFile / "version.sbt"
+      val VersionRegex   = """.*"(.*-SNAPSHOT)".*""".r
+
+      val currentPluginVersion = fr.getFileContent(versionSbtFile.getAbsolutePath) match {
+        case Right(VersionRegex(v)) => Some(v)
+        case _                      => None
+      }
+
+      val isTravisMaster = getEnvVarOrElse("TRAVIS_BRANCH", "") == "master" &&
+        getEnvVarOrElse("TRAVIS_PULL_REQUEST", "") == "true"
+
+      if (isTravisMaster && currentPluginVersion.isDefined)
+        Def.task(depUpdateDependencyIssues.value)
+      else
+        Def.task(streams.value.log.warn("Skipping auto-dependency check"))
+    }.value
   ): _*)

--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -23,7 +23,7 @@ object libraries {
   val v47: Map[String, String] = Map[String, String](
     "case-classy"           -> "0.4.0",
     "fetch"                 -> "0.6.1",
-    "github4s"              -> "0.14.5",
+    "github4s"              -> "0.14.6",
     "scheckToolboxDatetime" -> "0.2.1"
   )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -33,7 +33,7 @@ object ProjectPlugin extends AutoPlugin {
       addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"          % "0.7.0"),
       addSbtPlugin("com.geirsson"       % "sbt-scalafmt"           % "0.6.8"),
       addSbtPlugin("com.47deg"          % "sbt-dependencies"       % "0.1.1"),
-      addSbtPlugin("com.47deg"          % "sbt-microsites"         % "0.5.6")
+      addSbtPlugin("com.47deg"          % "sbt-microsites"         % "0.5.7")
     ) ++
       ScriptedPlugin.scriptedSettings ++ Seq(
       scriptedDependencies := (compile in Test) map { _ =>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.15")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.16")
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/src/main/scala/sbtorgpolicies/settings/enforcement.scala
+++ b/src/main/scala/sbtorgpolicies/settings/enforcement.scala
@@ -41,14 +41,16 @@ trait enforcement {
 
   private[this] def checkScalaVersion = Def.task {
     val scalaVersionValue = scalaVersion.value
-    if (scalaVersionValue != scalac.latestScalaVersion) {
+    val isSbtPlugin       = sbtPlugin.value
+    if (!isSbtPlugin && scalaVersionValue != scalac.latestScalaVersion) {
       throw ValidationException(s"scalaVersion is $scalaVersionValue. It should be ${scalac.latestScalaVersion}")
     }
   }
 
   private[this] def checkCrossScalaVersion = Def.task {
     val crossScalaVersionsValue = crossScalaVersions.value
-    if (!scalac.crossScalaVersions.forall(crossScalaVersionsValue.contains)) {
+    val isSbtPlugin             = sbtPlugin.value
+    if (!isSbtPlugin && !scalac.crossScalaVersions.forall(crossScalaVersionsValue.contains)) {
       throw ValidationException(s"""
            |crossScalaVersions is $crossScalaVersionsValue.
            |It should have at least these versions: ${scalac.crossScalaVersions.mkString(",")}""".stripMargin)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.17-SNAPSHOT"
+version in ThisBuild := "0.4.17"


### PR DESCRIPTION
This PR brings a new improvement for the auto-check module, avoiding a travis failure when dealing with a non-snapshot version. Besides that:

* Do not check the `checkCrossScalaVersion` and `checkCrossScalaVersion` when the artifact is an sbt plugin.
* Bumps sbt-microsites version, which is now binary compatible.
* Releases a new patch version with changes.

Please, @fedefernandez could you please take a look? Thanks!