### PR TITLE
Adds syntax to make easier the use of command aliases

### DIFF
--- a/core/src/main/scala/sbtorgpolicies/runnable/syntax.scala
+++ b/core/src/main/scala/sbtorgpolicies/runnable/syntax.scala
@@ -31,6 +31,9 @@ object syntax {
   implicit def runnableCommandOpsSyntax[T](command: String): RunnableCommandOps =
     new RunnableCommandOps(command)
 
+  implicit def runnableCommandListOpsSyntax[T](commandList: List[String]): RunnableCommandListOps =
+    new RunnableCommandListOps(commandList)
+
   final class RunnableTaskOps[T](taskKey: TaskKey[T]) {
 
     def asRunnableItemFull: RunnableItemConfigScope[T] =
@@ -77,6 +80,14 @@ object syntax {
         crossScalaVersions: Boolean): RunnableItemConfigScope[Unit] =
       RunnableItemConfigScope(RunnableProcess(command), allModules, aggregated, crossScalaVersions)
 
+    def asCmd: String =
+      if (command.contains("/")) s";project ${command.replaceAll("/", ";")}"
+      else s";$command"
+  }
+
+  final class RunnableCommandListOps(commandList: List[String]) {
+
+    def asCmd: String = commandList.map(_.asCmd).mkString("")
   }
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.16")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.18")
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
This PR brings some syntax helpers to make easier the use of command aliases.

For example, given this list of command aliases:

```
val commandAliases: Seq[Def.Setting[_]] =
    addCommandAlias("validate", ";clean;validateJS;validateJVM") ++
      addCommandAlias("validateDocs", List("docs/tut", "readme/tut", "project root").asCmd) ++
      addCommandAlias("validateCoverage", ";coverage;validate;coverageReport;coverageOff") ++
      addCommandAlias("validateJVM", List(
        "m1JVM/compile",
        "m2JVM/compile",
        "m1JVM/test",
        "m2JVM/test",
        "project root").asCmd) ++
      addCommandAlias("validateJS", List(
        "m1JS/compile",
        "m2JS/compile",
        "m1JS/test",
        "m2JS/test",
        "project root").asCmd)
```

Basically, `asCmd` will convert the `module/command` into: `;project module;command`.

Hence, you could define `orgScriptTaskListSetting` setting safely in this way:

```
orgScriptTaskListSetting := List(
        orgValidateFiles.asRunnableItem,
        "validateDocs".asRunnableItemFull,
        "validateCoverage".asRunnableItemFull
      )
```