### PR TITLE
Improves GitHubOps

### DIFF
--- a/core/src/main/scala/sbtorgpolicies/github/GitHubOps.scala
+++ b/core/src/main/scala/sbtorgpolicies/github/GitHubOps.scala
@@ -22,17 +22,17 @@ import cats.data.{EitherT, NonEmptyList}
 import cats.free.Free
 import cats.implicits._
 import cats.syntax.either._
-import com.github.marklister.base64.Base64.Encoder
+import com.github.marklister.base64.Base64._
 import github4s.Github
 import github4s.GithubResponses._
 import github4s.free.domain._
 import sbt.IO
 import sbtorgpolicies.exceptions.{GitHubException, IOException, OrgPolicyException}
+import sbtorgpolicies.github.config._
 import sbtorgpolicies.github.instances._
 import sbtorgpolicies.github.syntax._
 import sbtorgpolicies.io.syntax._
 import sbtorgpolicies.io.{FileReader, IOResult}
-import com.github.marklister.base64.Base64._
 
 class GitHubOps(owner: String, repo: String, accessToken: Option[String]) {
 

--- a/core/src/main/scala/sbtorgpolicies/github/config.scala
+++ b/core/src/main/scala/sbtorgpolicies/github/config.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package sbtorgpolicies
+package sbtorgpolicies.github
 
-package object github {
+object config {
 
   val blobMode: String = "100644"
   val blobType: String = "blob"

--- a/core/src/main/scala/sbtorgpolicies/github/package.scala
+++ b/core/src/main/scala/sbtorgpolicies/github/package.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sbtorgpolicies
+
+package object github {
+
+  val blobMode: String = "100644"
+  val blobType: String = "blob"
+
+  val defaultTextExtensions: Set[String] = Set(".md", ".css", ".html", ".properties", ".txt", ".scala", ".sbt")
+  val defaultMaximumSize: Int            = 4048
+
+  case class BlobConfig(acceptedExtensions: Set[String], maximumSize: Int)
+
+  val defaultBlobConfig: BlobConfig = BlobConfig(defaultTextExtensions, defaultMaximumSize)
+
+}


### PR DESCRIPTION
This PR tries to fix two main problems with the `GitHubOps.commitDir` method:

* *Too many requests* by sending some files in the `createCommit` operation body instead of creating a blob for all files (media and big files are still created with blob).
* *Timeouts* by creating one commit per directory, in this way we're minimizing the commit size and avoiding potential timeouts.