### PR TITLE
Enables Coursier by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,20 @@ after_success:
 - sbt ++$TRAVIS_SCALA_VERSION orgAfterCISuccess
 - sbt ++$TRAVIS_SCALA_VERSION publishLocal
 - cd autocheck && sbt -Dplugin.version=$(cat ../version.sbt | sed 's/.*"\(.*\)".*/\1/') checkDependencies
+
+cache:
+  directories:
+  - $HOME/.sbt/0.13
+  - $HOME/.sbt/boot/scala*
+  - $HOME/.sbt/cache
+  - $HOME/.sbt/launchers
+  - $HOME/.ivy2/cache
+  - $HOME/.coursier
+
+before_cache:
+- du -h -d 1 $HOME/.ivy2/
+- du -h -d 2 $HOME/.sbt/
+- du -h -d 4 $HOME/.coursier/
+- find $HOME/.sbt -name "*.lock" -type f -delete
+- find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
+- find $HOME/.coursier/cache -name "*.lock" -type f -delete

--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -21,11 +21,12 @@ object libraries {
   type Artifact = (String, String, String)
 
   val v47: Map[String, String] = Map[String, String](
-    "iota"                  -> "0.0.2",
-    "case-classy"           -> "0.4.0",
-    "fetch"                 -> "0.6.1",
-    "github4s"              -> "0.14.6",
-    "scheckToolboxDatetime" -> "0.2.1"
+    "iota"          -> "0.0.2",
+    "case-classy"   -> "0.4.0",
+    "fetch"         -> "0.6.1",
+    "freestyle"     -> "0.1.0-SNAPSHOT",
+    "github4s"      -> "0.14.6",
+    "scheckToolbox" -> "0.2.2"
   )
 
   protected val vOthers: Map[String, String] = Map[String, String](
@@ -33,7 +34,7 @@ object libraries {
     "akka-http"       -> "10.0.5",
     "algebra"         -> "0.7.0",
     "alleycats"       -> "0.1.9",
-    "aws-sdk"         -> "1.11.124",
+    "aws-sdk"         -> "1.11.125",
     "base64"          -> "0.2.3",
     "catalysts"       -> "0.0.5",
     "catbird"         -> "0.14.0",
@@ -49,7 +50,7 @@ object libraries {
     "fs2"             -> "0.9.5",
     "fs2-cats"        -> "0.3.0",
     "h2"              -> "1.4.195",
-    "http4s"          -> "0.17.0-M1",
+    "http4s"          -> "0.17.0-M2",
     "joda-convert"    -> "1.8.1",
     "joda-time"       -> "2.9.9",
     "journal"         -> "3.0.18",
@@ -116,11 +117,11 @@ object libraries {
     "algebra"                -> (("org.typelevel", "algebra", v("algebra"))),
     "alleycats"              -> (("org.typelevel", "alleycats-core", v("alleycats"))),
     "base64"                 -> (("com.github.marklister", "base64", v("base64"))),
-    "classy-cats"            -> (("com.fortysevendeg", "classy-cats", v("case-classy"))),
-    "classy-config-typesafe" -> (("com.fortysevendeg", "classy-config-typesafe", v("case-classy"))),
-    "classy-config-shocon"   -> (("com.fortysevendeg", "classy-config-shocon", v("case-classy"))),
-    "classy-core"            -> (("com.fortysevendeg", "classy-core", v("case-classy"))),
-    "classy-generic"         -> (("com.fortysevendeg", "classy-generic", v("case-classy"))),
+    "classy-cats"            -> (("com.47deg", "classy-cats", v("case-classy"))),
+    "classy-config-typesafe" -> (("com.47deg", "classy-config-typesafe", v("case-classy"))),
+    "classy-config-shocon"   -> (("com.47deg", "classy-config-shocon", v("case-classy"))),
+    "classy-core"            -> (("com.47deg", "classy-core", v("case-classy"))),
+    "classy-generic"         -> (("com.47deg", "classy-generic", v("case-classy"))),
     "catalysts-checklite"    -> (("org.typelevel", "catalysts-checklite", v("catalysts"))),
     "catalysts-lawkit"       -> (("org.typelevel", "catalysts-lawkit", v("catalysts"))),
     "catalysts-macros"       -> (("org.typelevel", "catalysts-macros", v("catalysts"))),
@@ -161,6 +162,7 @@ object libraries {
     "fetch-monix"            -> (("com.47deg", "fetch-monix", v("fetch"))),
     "fetch-debug"            -> (("com.47deg", "fetch-debug", v("fetch"))),
     "finch-core"             -> (("com.github.finagle", "finch-core", v("finch"))),
+    "freestyle"              -> (("com.47deg", "freestyle", v("freestyle"))),
     "fs2-core"               -> (("co.fs2", "fs2-core", v("fs2"))),
     "fs2-io"                 -> (("co.fs2", "fs2-io", v("fs2"))),
     "fs2-cats"               -> (("co.fs2", "fs2-cats", v("fs2-cats"))),
@@ -204,7 +206,9 @@ object libraries {
     "roshttp"                -> (("fr.hmil", "roshttp", v("roshttp"))),
     "scalacheck"             -> (("org.scalacheck", "scalacheck", v("scalacheck"))),
     "scheckShapeless"        -> (("com.github.alexarchambault", "scalacheck-shapeless_1.13", v("scheckShapeless"))),
-    "scheckToolboxDatetime"  -> (("com.fortysevendeg", "scalacheck-toolbox-datetime", v("scheckToolboxDatetime"))),
+    "scheckToolboxDatetime"  -> (("com.47deg", "scalacheck-toolbox-datetime", v("scheckToolbox"))),
+    "scheckToolboxMagic"     -> (("com.47deg", "scalacheck-toolbox-magic", v("scheckToolbox"))),
+    "scheckToolboxComb"      -> (("com.47deg", "scalacheck-toolbox-combinators", v("scheckToolbox"))),
     "scalaj"                 -> (("org.scalaj", "scalaj-http", v("scalaj"))),
     "scalatest"              -> (("org.scalatest", "scalatest", v("scalatest"))),
     "scalaz-concurrent"      -> (("org.scalaz", "scalaz-concurrent", v("scalaz"))),

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -28,10 +28,11 @@ object ProjectPlugin extends AutoPlugin {
       addSbtPlugin("pl.project13.scala" % "sbt-jmh"                % "0.2.24"),
       addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin" % "0.8.0"),
       addSbtPlugin("org.scoverage"      % "sbt-scoverage"          % "1.5.0"),
-      addSbtPlugin("org.scala-js"       % "sbt-scalajs"            % "0.6.15"),
+      addSbtPlugin("org.scala-js"       % "sbt-scalajs"            % "0.6.16"),
       addSbtPlugin("de.heikoseeberger"  % "sbt-header"             % "1.8.0"),
       addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"          % "0.7.0"),
       addSbtPlugin("com.geirsson"       % "sbt-scalafmt"           % "0.6.8"),
+      addSbtPlugin("io.get-coursier"    % "sbt-coursier"           % "1.0.0-RC1"),
       addSbtPlugin("com.47deg"          % "sbt-dependencies"       % "0.1.1"),
       addSbtPlugin("com.47deg"          % "sbt-microsites"         % "0.5.7")
     ) ++

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.18")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.4.19")
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value

--- a/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
@@ -144,7 +144,7 @@ trait AllSettings
     scalaJSStage in Global := FastOptStage,
     parallelExecution := false,
     requiresDOM := false,
-    jsEnv := NodeJSEnv().value,
+    jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
     // batch mode decreases the amount of memory needed to compile scala.js code
     scalaJSOptimizerOptions := scalaJSOptimizerOptions.value.withBatchMode(getEnvVar("TRAVIS").isDefined)
   )


### PR DESCRIPTION
This PR mainly enables `coursier` by default, but it also:

* Updates outdated deps, like `scalajs` and `http4s`.
* Changes case-classy and scalacheck-toolbox to `com.47deg` group id.
* Adds freestyle to the catalogue.
* Removes deprecation warning related to `new org.scalajs.jsenv.nodejs.NodeJSEnv()`