### PR TITLE
Upgrading coursier version

### DIFF
--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -44,7 +44,7 @@ object libraries {
     "cats-effect"              -> "0.3",
     "circe"                    -> "0.8.0",
     "config"                   -> "1.3.1",
-    "coursier"                 -> "1.0.0-RC8",
+    "coursier"                 -> "1.0.0-RC9",
     "discipline"               -> "0.8",
     "doobie"                   -> "0.4.1",
     "embedded-redis"           -> "0.6",

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -35,7 +35,7 @@ object ProjectPlugin extends AutoPlugin {
       addSbtPlugin("de.heikoseeberger"  % "sbt-header"             % "1.8.0"),
       addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"          % "0.7.0"),
       addSbtPlugin("com.geirsson"       % "sbt-scalafmt"           % "0.6.8"),
-      addSbtPlugin("io.get-coursier"    % "sbt-coursier"           % "1.0.0-RC8"),
+      addSbtPlugin("io.get-coursier"    % "sbt-coursier"           % "1.0.0-RC9"),
       addSbtPlugin("com.47deg"          % "sbt-dependencies"       % "0.1.1"),
       addSbtPlugin("com.47deg"          % "sbt-microsites"         % "0.6.1" exclude("org.tpolecat", "tut-plugin"))
     ) ++

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC8")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC9")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.13-SNAPSHOT"
+version in ThisBuild := "0.5.13"


### PR DESCRIPTION
This PR updates the coursier versions to 1.0.0-RC9, and releases a new 0.5.13 version. 

@juanpedromoreno could you please review?

Thanks!