### PR TITLE
Release 0.6.0

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.0-SNAPSHOT"
+version in ThisBuild := "0.6.0"


### PR DESCRIPTION
I am 95% sure the merge to master will fail because there is a `checkSnapshotDependencies` in `sbt release`. This depends on `sbt-org-policies`:`0.6.0-SNAPSHOT`... I will probably need to `sbt release` manually with that line commented.

https://github.com/47deg/sbt-org-policies/blob/master/src/main/scala/sbtorgpolicies/settings/AllSettings.scala#L79