### PR TITLE
Release 0.6.2

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers += Resolver.sonatypeRepo("snapshots")
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.6.0-SNAPSHOT")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.6.2-SNAPSHOT")
 
 libraryDependencies += {
   lazy val sbtVersionValue = (sbtVersion in pluginCrossBuild).value

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.2-SNAPSHOT"
+version in ThisBuild := "0.6.2"


### PR DESCRIPTION
And another. I should not have released `0.6.1`. It didn't have anything useful.

`0.6.2-SNAPSHOT` has the updated `releaseProcess` and will get used in the `0.6.2` release.