### PR TITLE
Update 0.6.3 snapshot

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,8 @@ lazy val `sbt-org-policies` = (project in file("."))
 lazy val `org-policies-core` = (project in file("core"))
   .settings(moduleName := "org-policies-core")
   .settings(coreSettings: _*)
+  .enablePlugins(BuildInfoPlugin)
+  .settings(buildInfoSettings: _*)
 
 addCommandAlias("publishLocalAll", ";org-policies-core/publishLocal;sbt-org-policies/publishLocal")
 

--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -26,6 +26,7 @@ object libraries {
     "fetch"         -> "0.6.2",
     "freestyle"     -> "0.3.1",
     "github4s"      -> "0.15.0",
+    "org-policies"  -> sbtorgpolicies.BuildInfo.version,
     "scheckToolbox" -> "0.2.2"
   )
 
@@ -259,6 +260,7 @@ object libraries {
     "monocle-macro"          -> (("com.github.julien-truffaut", "monocle-macro", v("monocle"))),
     "monocle-state"          -> (("com.github.julien-truffaut", "monocle-state", v("monocle"))),
     "moultingyaml"           -> (("net.jcazevedo", "moultingyaml", v("moultingyaml"))),
+    "org-policies-core"      -> (("com.47deg", "org-policies-core", v("org-policies"))),
     "pcplod"                 -> (("org.ensime", "pcplod", v("pcplod"))),
     "play"                   -> (("com.typesafe.play", "play", v("play"))),
     "play-test"              -> (("com.typesafe.play", "play-test", v("play"))),
@@ -305,15 +307,16 @@ object libraries {
     "sbt-header"  -> (("de.heikoseeberger", "sbt-header", v("sbt-header"))),
     "sbt-jmh"     -> (("pl.project13.scala", "sbt-jmh", v("sbt-jmh"))),
     // "sbt-microsites"   -> (("com.47deg", "sbt-microsites", v("sbt-microsites"))),
-    "sbt-pgp"       -> (("com.jsuereth", "sbt-pgp", v("sbt-pgp"))),
-    "sbt-release"   -> (("com.github.gseitz", "sbt-release", v("sbt-release"))),
-    "sbt-site"      -> (("com.typesafe.sbt", "sbt-site", v("sbt-site"))),
-    "sbt-scalafmt"  -> (("com.geirsson", "sbt-scalafmt", v("sbt-scalafmt"))),
-    "sbt-scalajs"   -> (("org.scala-js", "sbt-scalajs", v("sbt-scalajs"))),
-    "sbt-scoverage" -> (("org.scoverage", "sbt-scoverage", v("sbt-scoverage"))),
-    "sbt-sonatype"  -> (("org.xerial.sbt", "sbt-sonatype", v("sbt-sonatype"))),
-    "sbt-unidoc"    -> (("com.eed3si9n", "sbt-unidoc", v("sbt-unidoc"))),
-    "tut-plugin"    -> (("org.tpolecat", "tut-plugin", v("tut-plugin")))
+    "sbt-org-policies" -> (("com.47deg", "sbt-org-policies", v("org-policies"))),
+    "sbt-pgp"          -> (("com.jsuereth", "sbt-pgp", v("sbt-pgp"))),
+    "sbt-release"      -> (("com.github.gseitz", "sbt-release", v("sbt-release"))),
+    "sbt-site"         -> (("com.typesafe.sbt", "sbt-site", v("sbt-site"))),
+    "sbt-scalafmt"     -> (("com.geirsson", "sbt-scalafmt", v("sbt-scalafmt"))),
+    "sbt-scalajs"      -> (("org.scala-js", "sbt-scalajs", v("sbt-scalajs"))),
+    "sbt-scoverage"    -> (("org.scoverage", "sbt-scoverage", v("sbt-scoverage"))),
+    "sbt-sonatype"     -> (("org.xerial.sbt", "sbt-sonatype", v("sbt-sonatype"))),
+    "sbt-unidoc"       -> (("com.eed3si9n", "sbt-unidoc", v("sbt-unidoc"))),
+    "tut-plugin"       -> (("org.tpolecat", "tut-plugin", v("tut-plugin")))
   )
 
   val pluginScalaLibs: Map[String, Artifact] = Map[String, Artifact](

--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -100,7 +100,7 @@ object libraries {
   )
 
   val vPlugins47: Map[String, String] = Map[String, String](
-    "sbt-dependencies" -> "0.1.1",
+    "sbt-dependencies" -> "0.2.0",
     "sbt-microsites"   -> "0.5.7"
   )
 
@@ -299,8 +299,8 @@ object libraries {
   )
 
   val pluginLibs: Map[String, Artifact] = Map[String, Artifact](
-    "sbt-buildinfo" -> (("com.eed3si9n", "sbt-buildinfo", v("sbt-buildinfo"))),
-    // "sbt-dependencies" -> (("com.47deg", "sbt-dependencies", v("sbt-dependencies"))),
+    "sbt-buildinfo"    -> (("com.eed3si9n", "sbt-buildinfo", v("sbt-buildinfo"))),
+    "sbt-dependencies" -> (("com.47deg", "sbt-dependencies", v("sbt-dependencies"))),
     // "sbt-coursier"     -> (("io.get-coursier", "sbt-coursier", v("coursier"))),
     "sbt-ghpages" -> (("com.typesafe.sbt", "sbt-ghpages", v("sbt-ghpages"))),
     "sbt-git"     -> (("com.typesafe.sbt", "sbt-git", v("sbt-git"))),

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -9,6 +9,7 @@ import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 import sbtorgpolicies.runnable.syntax._
 import sbtorgpolicies.templates.badges._
 import sbtorgpolicies.model.scalac
+import sbtbuildinfo.BuildInfoPlugin.autoImport._
 
 object ProjectPlugin extends AutoPlugin {
 
@@ -182,6 +183,10 @@ object ProjectPlugin extends AutoPlugin {
       if (sbt210) addSbtPlugin(module exclude210Suffixes, "0.13", "2.10")
       else addSbtPlugin(module)
 
+    lazy val buildInfoSettings: Seq[Def.Setting[_]] = Seq(
+      buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+      buildInfoPackage := "sbtorgpolicies"
+    )
   }
 
   override def projectSettings: Seq[Def.Setting[_]] = artifactSettings //++ shellPromptSettings

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -189,7 +189,7 @@ object ProjectPlugin extends AutoPlugin {
     )
   }
 
-  override def projectSettings: Seq[Def.Setting[_]] = artifactSettings //++ shellPromptSettings
+  override def projectSettings: Seq[Def.Setting[_]] = artifactSettings ++ shellPromptSettings
 
   private[this] val artifactSettings = Seq(
     scalaVersion := scalac.`2.12`,

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,4 +1,4 @@
-//import dependencies.DependenciesPlugin.autoImport.depUpdateDependencyIssues
+import dependencies.DependenciesPlugin.autoImport.depUpdateDependencyIssues
 import sbt.Keys._
 import sbt.Resolver.sonatypeRepo
 import sbt.ScriptedPlugin.autoImport._
@@ -193,7 +193,7 @@ object ProjectPlugin extends AutoPlugin {
       MavenCentralBadge.apply,
       LicenseBadge.apply,
       GitHubIssuesBadge.apply
-    ) //,
-//    orgAfterCISuccessTaskListSetting ~= (_ filterNot(_ == depUpdateDependencyIssues.asRunnableItem))
+    ),
+    orgAfterCISuccessTaskListSetting ~= (_ filterNot (_ == depUpdateDependencyIssues.asRunnableItem))
   )
 }

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -73,6 +73,7 @@ object ProjectPlugin extends AutoPlugin {
       addSbtPlugin("org.scala-js"       % "sbt-scalajs"            % "0.6.19"),
       addSbtPlugin("de.heikoseeberger"  % "sbt-header"             % "3.0.1"),
       addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"          % "0.7.0"),
+      addSbtPlugin("com.47deg"          % "sbt-dependencies"       % "0.2.0"),
       // addSbtPlugin("com.lucidchart"     % "sbt-scalafmt"  % "1.10"),
       // addSbtPlugin("com.geirsson"       % "sbt-scalafmt"  % "1.2.0"),
       libraryDependencies ++= {
@@ -98,7 +99,6 @@ object ProjectPlugin extends AutoPlugin {
         )
       }
 //      addSbtPlugin("io.get-coursier"          % "sbt-coursier"           % "1.0.0-RC11"),
-//      addCustomSBTPlugin("com.47deg"          % "sbt-dependencies"       % "0.1.1", sbt210 = true),
 //      addCustomSBTPlugin("com.47deg"          % "sbt-microsites"         % "0.6.1", sbt210 = true)
     ) ++ Seq(
       scriptedLaunchOpts := {

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -123,21 +123,14 @@ object ProjectPlugin extends AutoPlugin {
         }
       },
       libraryDependencies ++= Seq(
-        "com.47deg"             %% "github4s"                    % "0.15.0",
-        "org.typelevel"         %% "cats-core"                   % "0.9.0",
-        "com.github.marklister" %% "base64"                      % "0.2.3",
-        "net.jcazevedo"         %% "moultingyaml"                % "0.4.0",
-        "org.scalatest"         %% "scalatest"                   % "3.0.3" % Test,
-        "org.scalacheck"        %% "scalacheck"                  % "1.13.4" % Test,
-        "com.47deg"             %% "scalacheck-toolbox-datetime" % "0.2.2" % Test,
-        "org.scalamock"         %% "scalamock-scalatest-support" % "3.5.0" % Test
-//        %%("github4s"),
-//        %%("cats"),
-//        %%("base64"),
-//        %%("moultingyaml"),
-//        %%("scalatest")             % Test,
-//        %%("scalacheck")            % Test,
-//        %%("scheckToolboxDatetime") % Test,
+        %%("github4s"),
+        %%("cats-core"),
+        %%("base64"),
+        %%("moultingyaml"),
+        %%("scalatest")             % Test,
+        %%("scalacheck")            % Test,
+        %%("scheckToolboxDatetime") % Test,
+        %%("scalamockScalatest")    % Test,
       ),
       libraryDependencies ++= {
         lazy val sbtVersionValue = (sbtVersion in pluginCrossBuild).value

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -140,11 +140,12 @@ object ProjectPlugin extends AutoPlugin {
             Seq(
               "org.scala-sbt" % "scripted-plugin" % sbtVersionValue
             )
-          case _ =>
+          case scalac.`2.12` =>
             Seq(
               "org.scala-lang.modules" %% "scala-xml"       % "1.0.6",
               "org.scala-sbt"          %% "scripted-plugin" % sbtVersionValue
             )
+          case _ => Nil
         }
       }
     )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,12 +2,3 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.6.3-SNAPSHOT")
 // remove after a version of sbt-org-policies is published with sbt-dependencies
 addSbtPlugin("com.47deg" % "sbt-dependencies" % "0.2.0")
-
-libraryDependencies += {
-  lazy val sbtVersionValue = (sbtVersion in pluginCrossBuild).value
-
-  scalaVersion.value match {
-    case "2.10.6" => "org.scala-sbt" % "scripted-plugin"  % sbtVersionValue
-    case _        => "org.scala-sbt" %% "scripted-plugin" % sbtVersionValue
-  }
-}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
 resolvers += Resolver.sonatypeRepo("snapshots")
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.6.2-SNAPSHOT")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.6.3-SNAPSHOT")
+// remove after a version of sbt-org-policies is published with sbt-dependencies
+addSbtPlugin("com.47deg" % "sbt-dependencies" % "0.2.0")
 
 libraryDependencies += {
   lazy val sbtVersionValue = (sbtVersion in pluginCrossBuild).value

--- a/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
@@ -18,8 +18,8 @@ package sbtorgpolicies.settings
 
 import com.typesafe.sbt.pgp.PgpKeys
 import com.typesafe.sbt.pgp.PgpKeys._
-//import dependencies.DependenciesPlugin
-//import dependencies.DependenciesPlugin.autoImport._
+import dependencies.DependenciesPlugin
+import dependencies.DependenciesPlugin.autoImport._
 //import microsites.MicrositeKeys._
 import scoverage.ScoverageKeys
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
@@ -232,18 +232,18 @@ trait AllSettings
     }
   )
 
-//  /**
-//   * Sets the default properties for the sbt-dependencies plugin
-//   *
-//   * Uses the github settings to set the GitHub owner and repo
-//   */
-//  val sbtDependenciesSettings: Seq[Setting[_]] =
-//    DependenciesPlugin.defaultSettings ++ Seq(
-//      depGithubOwnerSetting := orgGithubSetting.value.organization,
-//      depGithubRepoSetting := orgGithubSetting.value.project,
-//      depGithubTokenSetting := getEnvVar(orgGithubTokenSetting.value)
-//    )
-//
+  /**
+   * Sets the default properties for the sbt-dependencies plugin
+   *
+   * Uses the github settings to set the GitHub owner and repo
+   */
+  val sbtDependenciesSettings: Seq[Setting[_]] =
+    DependenciesPlugin.defaultSettings ++ Seq(
+      depGithubOwnerSetting := orgGithubSetting.value.organization,
+      depGithubRepoSetting := orgGithubSetting.value.project,
+      depGithubTokenSetting := getEnvVar(orgGithubTokenSetting.value)
+    )
+
 //  /**
 //   * Sets the default properties for the sbt-microsites plugin.
 //   *

--- a/src/main/scala/sbtorgpolicies/settings/DefaultSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/DefaultSettings.scala
@@ -56,7 +56,7 @@ trait DefaultSettings extends AllSettings {
       orgEnforcementSettingsTasks ++
       orgBashTasks ++
       orgCommonTasks ++
-//      sbtDependenciesSettings ++
+      sbtDependenciesSettings ++
 //      sbtMicrositesSettings ++
       AutomateHeaderPlugin.autoImport.automateHeaderSettings(Compile, Test)
 


### PR DESCRIPTION
* Add `sbt-dependencies`:`0.2.0`
* enable `BuildInfoPlugin`
  * so that https://github.com/47deg/sbt-dependencies/blob/d4335771a9a20faa8019bafdba9db28220c082c1/project/ProjectPlugin.scala#L22 can be replaced with `%%("org-policies-core")`
    * one less place to update the `sbt-org-policies` version