### PR TITLE
Release 0.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,14 @@ after_success:
       if grep -q "SNAPSHOT" version.sbt; then
         sbt ^^$SBT_VERSION publish;
       else
-        sbt ^^$SBT_VERSION release;
+        if [ "$SBT_VERSION" = "1.0.1" ]; then
+          sbt ^^$SBT_VERSION orgUpdateDocFiles;
+          git reset --hard HEAD;
+          git clean -f;
+          git checkout master;
+          git pull origin master;
+          sbt ^^$SBT_VERSION release;
+        fi
       fi
     fi
   - sbt ^^$SBT_VERSION publishLocal

--- a/autocheck/build.sbt
+++ b/autocheck/build.sbt
@@ -46,8 +46,7 @@ lazy val `org-policies-auto-dep-check` = (project in file("."))
         getEnvVarOrElse("TRAVIS_PULL_REQUEST") == "false"
 
       if (isTravisMaster && currentPluginVersion.isDefined)
-        // Def.task(depUpdateDependencyIssues.value)
-        Def.task()
+        Def.task(depUpdateDependencyIssues.value)
       else
         Def.task(streams.value.log.warn("Skipping auto-dependency check"))
     }.value

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -8,7 +8,7 @@ import sbtorgpolicies.OrgPoliciesPlugin
 import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 import sbtorgpolicies.runnable.syntax._
 import sbtorgpolicies.templates.badges._
-import sbtorgpolicies.model.scalac
+import sbtorgpolicies.model.{sbtV, scalac}
 import sbtbuildinfo.BuildInfoPlugin.autoImport._
 
 object ProjectPlugin extends AutoPlugin {
@@ -16,26 +16,6 @@ object ProjectPlugin extends AutoPlugin {
   override def requires: Plugins = OrgPoliciesPlugin
 
   override def trigger: PluginTrigger = allRequirements
-
-  object sbtV {
-    val `0.13`: String = "0.13.16"
-    val `1.0`: String  = "1.0.1"
-
-    val crossSbtVersions: List[String] = List(`0.13`, `1.0`)
-  }
-
-  object scalac {
-
-    val `2.10`: String = "2.10.6"
-    val `2.11`: String = "2.11.11"
-    val `2.12`: String = "2.12.3"
-    val `2.13`: String = "2.13.0-M1"
-
-    val latestScalaVersion: String = `2.12`
-
-    val crossScalaVersions: List[String] = List(`2.11`, `2.12`)
-
-  }
 
   object autoImport {
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,2 @@
 resolvers += Resolver.sonatypeRepo("snapshots")
 addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.6.3-SNAPSHOT")
-// remove after a version of sbt-org-policies is published with sbt-dependencies
-addSbtPlugin("com.47deg" % "sbt-dependencies" % "0.2.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.3-SNAPSHOT"
+version in ThisBuild := "0.6.3"


### PR DESCRIPTION
* Update travis.yml to match `sbt-dependencies`
* Add `sbt-dependencies` task back to autocheck project
* Cleanup of redundant `object`s and sbt plugin

