### PR TITLE
Replaces scripted dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ before_install:
 
 script:
   - sbt ^^$SBT_VERSION clean compile test
-  - if [ "$TRAVIS_BRANCH" = "master" ]; then
-      sbt ^^$SBT_VERSION scripted;
-    fi
+  - sbt ^^$SBT_VERSION scripted
 
 after_success:
   - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,12 @@ lazy val `org-policies-core` = (project in file("core"))
   .settings(moduleName := "org-policies-core")
   .settings(coreSettings: _*)
   .enablePlugins(BuildInfoPlugin)
-  .settings(buildInfoSettings: _*)
+  .settings(
+    Seq(
+      buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+      buildInfoPackage := "sbtorgpolicies"
+    ): _*
+  )
 
 addCommandAlias("publishLocalAll", ";org-policies-core/publishLocal;sbt-org-policies/publishLocal")
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,7 +1,8 @@
 import dependencies.DependenciesPlugin.autoImport.depUpdateDependencyIssues
 import sbt.Keys._
 import sbt.Resolver.sonatypeRepo
-import sbt.{Def, _}
+import sbt._
+import sbt.ScriptedPlugin.autoImport._
 import sbtorgpolicies.OrgPoliciesKeys.orgAfterCISuccessTaskListSetting
 import sbtorgpolicies.OrgPoliciesPlugin
 import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
@@ -73,6 +74,16 @@ object ProjectPlugin extends AutoPlugin {
             sbtBinaryVersionValue,
             scalaBinaryVersionValue)
         )
+      },
+      scriptedLaunchOpts := {
+        scriptedLaunchOpts.value ++
+          Seq(
+            "-Xmx2048M",
+            "-XX:ReservedCodeCacheSize=256m",
+            "-XX:+UseConcMarkSweepGC",
+            "-Dplugin.version=" + version.value,
+            "-Dscala.version=" + scalaVersion.value
+          )
       }
 //      addSbtPlugin("io.get-coursier"          % "sbt-coursier"           % "1.0.0-RC11"),
 //      addCustomSBTPlugin("com.47deg"          % "sbt-microsites"         % "0.6.1", sbt210 = true)

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,7 +1,6 @@
 import dependencies.DependenciesPlugin.autoImport.depUpdateDependencyIssues
 import sbt.Keys._
 import sbt.Resolver.sonatypeRepo
-import sbt.ScriptedPlugin.autoImport._
 import sbt.{Def, _}
 import sbtorgpolicies.OrgPoliciesKeys.orgAfterCISuccessTaskListSetting
 import sbtorgpolicies.OrgPoliciesPlugin
@@ -9,7 +8,6 @@ import sbtorgpolicies.OrgPoliciesPlugin.autoImport._
 import sbtorgpolicies.runnable.syntax._
 import sbtorgpolicies.templates.badges._
 import sbtorgpolicies.model.{sbtV, scalac}
-import sbtbuildinfo.BuildInfoPlugin.autoImport._
 
 object ProjectPlugin extends AutoPlugin {
 
@@ -40,7 +38,7 @@ object ProjectPlugin extends AutoPlugin {
       sbtPlugin := true,
       crossSbtVersions := Seq(sbtV.`0.13`, sbtV.`1.0`),
       resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases")),
-      addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3" commonExcludes),
+      addSbtPlugin("com.typesafe.sbt"   % "sbt-git"                % "0.9.3"),
       addSbtPlugin("com.eed3si9n"       % "sbt-unidoc"             % "0.4.1"),
       addSbtPlugin("com.github.gseitz"  % "sbt-release"            % "1.0.6"),
       addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"           % "2.0"),
@@ -52,19 +50,17 @@ object ProjectPlugin extends AutoPlugin {
       addSbtPlugin("org.scoverage"      % "sbt-scoverage"          % "1.5.1"),
       addSbtPlugin("org.scala-js"       % "sbt-scalajs"            % "0.6.19"),
       addSbtPlugin("de.heikoseeberger"  % "sbt-header"             % "3.0.1"),
-      addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"          % "0.7.0"),
       addSbtPlugin("com.47deg"          % "sbt-dependencies"       % "0.2.0"),
       // addSbtPlugin("com.lucidchart"     % "sbt-scalafmt"  % "1.10"),
       // addSbtPlugin("com.geirsson"       % "sbt-scalafmt"  % "1.2.0"),
       libraryDependencies ++= {
-        val sbtVersionValue       = (sbtVersion in pluginCrossBuild).value
         val sbtBinaryVersionValue = (sbtBinaryVersion in pluginCrossBuild).value
 
         val scalaBinaryVersionValue = (scalaBinaryVersion in update).value
 
-        val (tutPluginVersion, sbtScalafmtVersion) = sbtVersionValue match {
-          case sbtV.`0.13` => ("0.5.3", "0.6.8")
-          case sbtV.`1.0`  => ("0.6.0", "1.2.0")
+        val (tutPluginVersion, sbtScalafmtVersion) = sbtBinaryVersionValue match {
+          case "0.13" => ("0.5.3", "0.6.8")
+          case "1.0"  => ("0.6.0", "1.2.0")
         }
 
         Seq(
@@ -80,26 +76,15 @@ object ProjectPlugin extends AutoPlugin {
       }
 //      addSbtPlugin("io.get-coursier"          % "sbt-coursier"           % "1.0.0-RC11"),
 //      addCustomSBTPlugin("com.47deg"          % "sbt-microsites"         % "0.6.1", sbt210 = true)
-    ) ++ Seq(
-      scriptedLaunchOpts := {
-        scriptedLaunchOpts.value ++
-          Seq(
-            "-Xmx2048M",
-            "-XX:ReservedCodeCacheSize=256m",
-            "-XX:+UseConcMarkSweepGC",
-            "-Dplugin.version=" + version.value,
-            "-Dscala.version=" + scalaVersion.value
-          )
-      }
     )
 
     lazy val coreSettings: Seq[Def.Setting[_]] = commonSettings ++ Seq(
       resolvers += Resolver.typesafeIvyRepo("releases"),
       crossScalaVersions := Seq(scalac.`2.10`, scalac.`2.12`),
       scalaVersion := {
-        (sbtVersion in pluginCrossBuild).value match {
-          case sbtV.`0.13` => scalac.`2.10`
-          case sbtV.`1.0`  => scalac.`2.12`
+        (sbtBinaryVersion in pluginCrossBuild).value match {
+          case "0.13" => scalac.`2.10`
+          case "1.0"  => scalac.`2.12`
         }
       },
       libraryDependencies ++= Seq(
@@ -118,49 +103,18 @@ object ProjectPlugin extends AutoPlugin {
         (scalaVersion in update).value match {
           case scalac.`2.10` =>
             Seq(
-              "org.scala-sbt" % "scripted-plugin" % sbtVersionValue
+              "org.scala-sbt" % "sbt" % sbtVersionValue % "provided"
             )
           case scalac.`2.12` =>
             Seq(
-              "org.scala-lang.modules" %% "scala-xml"       % "1.0.6",
-              "org.scala-sbt"          %% "scripted-plugin" % sbtVersionValue
+              "org.scala-lang.modules" %% "scala-xml" % "1.0.6",
+              "org.scala-sbt"          % "sbt"        % sbtVersionValue % "provided"
             )
           case _ => Nil
         }
       }
     )
 
-    implicit class ModuleExcludes(module: ModuleID) {
-
-      def commonExcludes: ModuleID =
-        module
-          .exclude("javax.jms", "jms")
-          .exclude("com.sun.jdmk", "jmxtools")
-          .exclude("com.sun.jmx", "jmxri")
-
-      def exclude210Suffixes: ModuleID =
-        module
-          .excludeAll(ExclusionRule(organization = "org.scala-sbt"))
-          .excludeAll(ExclusionRule(organization = "com.github.mpilquist"))
-          .excludeAll(ExclusionRule(organization = "org.typelevel"))
-          .excludeAll(ExclusionRule(organization = "io.circe"))
-          .excludeAll(ExclusionRule(organization = "com.chuusai"))
-          .excludeAll(ExclusionRule(organization = "com.lihaoyi"))
-          .excludeAll(ExclusionRule(organization = "com.github.nscala-time"))
-          .excludeAll(ExclusionRule(organization = "net.jcazevedo"))
-          .excludeAll(ExclusionRule(organization = "com.github.marklister"))
-          .excludeAll(ExclusionRule(organization = "org.scalaj"))
-          .exclude("com.47deg", "github4s")
-    }
-
-    private[this] def addPlugin(module: ModuleID, sbt210: Boolean = false) =
-      if (sbt210) addSbtPlugin(module exclude210Suffixes, "0.13", "2.10")
-      else addSbtPlugin(module)
-
-    lazy val buildInfoSettings: Seq[Def.Setting[_]] = Seq(
-      buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
-      buildInfoPackage := "sbtorgpolicies"
-    )
   }
 
   override def projectSettings: Seq[Def.Setting[_]] = artifactSettings ++ shellPromptSettings

--- a/project/buildinfo.sbt
+++ b/project/buildinfo.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 resolvers += Resolver.sonatypeRepo("snapshots")
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.6.3-SNAPSHOT")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.6.4-SNAPSHOT")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,4 @@
-resolvers += Resolver.sonatypeRepo("snapshots")
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.6.4-SNAPSHOT")
+import sbt.Resolver.sonatypeRepo
+
+resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases"))
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.6.4-M1")

--- a/project/scripted.sbt
+++ b/project/scripted.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.4-SNAPSHOT"
+version in ThisBuild := "0.6.4"


### PR DESCRIPTION
...  by sbt `"provided"` dependency. From now on, `org-policies-core` won't provide transitively the scripted dependency anymore. It also:

* Removes non-used code.
* Releases new 0.6.4 version.

