### PR TITLE
Updates Scalameta Settings

### DIFF
--- a/core/src/main/scala/sbtorgpolicies/github/GitHubOps.scala
+++ b/core/src/main/scala/sbtorgpolicies/github/GitHubOps.scala
@@ -19,7 +19,6 @@ package sbtorgpolicies.github
 import java.io.File
 
 import cats.data.{EitherT, NonEmptyList}
-import cats.free.Free
 import cats.implicits._
 import com.github.marklister.base64.Base64._
 import github4s.Github

--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -55,7 +55,7 @@ object libraries {
     "fs2-cats"                 -> "0.4.0",
     "h2"                       -> "1.4.196",
     "http4s"                   -> "0.18.0-M1",
-    "joda-convert"             -> "1.8.3",
+    "joda-convert"             -> "1.9",
     "joda-time"                -> "2.9.9",
     "journal"                  -> "3.0.18",
     "jwt-scala"                -> "0.14.0",
@@ -100,7 +100,7 @@ object libraries {
   )
 
   val vPlugins47: Map[String, String] = Map[String, String](
-    "sbt-dependencies" -> "0.2.0",
+    "sbt-dependencies" -> "0.3.1",
     "sbt-microsites"   -> "0.7.0"
   )
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -51,7 +51,7 @@ object ProjectPlugin extends AutoPlugin {
       addSbtPlugin("org.scoverage"      % "sbt-scoverage"          % "1.5.1"),
       addSbtPlugin("org.scala-js"       % "sbt-scalajs"            % "0.6.20"),
       addSbtPlugin("de.heikoseeberger"  % "sbt-header"             % "3.0.1"),
-      addSbtPlugin("com.47deg"          % "sbt-dependencies"       % "0.2.0"),
+      addSbtPlugin("com.47deg"          % "sbt-dependencies"       % "0.3.1"),
       // addSbtPlugin("com.lucidchart"     % "sbt-scalafmt"  % "1.10"),
       // addSbtPlugin("com.geirsson"       % "sbt-scalafmt"  % "1.2.0"),
       libraryDependencies ++= {

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -85,8 +85,7 @@ object ProjectPlugin extends AutoPlugin {
             "-Dscala.version=" + scalaVersion.value
           )
       },
-      addSbtPlugin("io.get-coursier" % "sbt-coursier"   % "1.0.0-RC11"),
-      addSbtPlugin("com.47deg"       % "sbt-microsites" % "0.7.0")
+      addSbtPlugin("com.47deg" % "sbt-microsites" % "0.7.0")
     )
 
     lazy val coreSettings: Seq[Def.Setting[_]] = commonSettings ++ Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 import sbt.Resolver.sonatypeRepo
 
 resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases"))
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.6.4")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.7.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 import sbt.Resolver.sonatypeRepo
 
 resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases"))
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.7.1")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.7.2-M1")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC11")

--- a/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
@@ -119,8 +119,9 @@ trait AllSettings
 
   lazy val scalaMetaSettings = Seq(
     addCompilerPlugin(%%("scalameta-paradise") cross CrossVersion.full),
-    libraryDependencies += %%("scalameta"),
-    scalacOptions += "-Xplugin-require:macroparadise"
+    libraryDependencies += %%("scalameta", "1.8.0"),
+    scalacOptions += "-Xplugin-require:macroparadise",
+    scalacOptions in (Compile, console) ~= (_ filterNot (_ contains "paradise")) // macroparadise plugin doesn't work in repl yet.
   )
 
   /**
@@ -131,7 +132,6 @@ trait AllSettings
   lazy val sharedJsSettings = Seq(
     scalaJSStage in Global := FastOptStage,
     parallelExecution := false,
-    requiresDOM := false,
     jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
     // batch mode decreases the amount of memory needed to compile scala.js code
     scalaJSOptimizerOptions := scalaJSOptimizerOptions.value.withBatchMode(getEnvVar("TRAVIS").isDefined)

--- a/src/main/scala/sbtorgpolicies/settings/DefaultSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/DefaultSettings.scala
@@ -24,7 +24,7 @@ import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{
   HeaderFileType,
   HeaderLicense
 }
-//import dependencies.DependenciesPlugin.autoImport._
+import dependencies.DependenciesPlugin.autoImport._
 import scoverage.ScoverageKeys
 import scoverage.ScoverageKeys.coverageEnabled
 import sbtorgpolicies.runnable.SetSetting
@@ -131,7 +131,7 @@ trait DefaultSettings extends AllSettings {
     },
     orgAfterCISuccessTaskListSetting := List(
       orgUpdateDocFiles.asRunnableItem,
-//      depUpdateDependencyIssues.asRunnableItem,
+      depUpdateDependencyIssues.asRunnableItem,
       orgPublishReleaseTask.asRunnableItem(allModules = true, aggregated = false, crossScalaVersions = true)
     ) ++ guard(((baseDirectory in LocalRootProject).value / "docs").exists() && !version.value.endsWith("-SNAPSHOT"))(
       defaultPublishMicrosite),

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.2-SNAPSHOT"
+version in ThisBuild := "0.7.2"


### PR DESCRIPTION
This PR changes the scalameta settings according to [its tutorial](http://scalameta.org/paradise/), where it's using scalameta paradise `3.0.0-M10` together with scalameta `1.8.0` (instead of `2.0.0`, it seems to be incompatible).

```scala
lazy val macroAnnotationSettings = Seq(
  addCompilerPlugin("org.scalameta" % "paradise" % "3.0.0-M10" cross CrossVersion.full),
  scalacOptions += "-Xplugin-require:macroparadise",
  scalacOptions in (Compile, console) ~= (_ filterNot (_ contains "paradise")) // macroparadise plugin doesn't work in repl yet.
)
// Requires scalaVersion 2.11.11 or 2.12.3
lazy val projectThatDefinesMacroAnnotations = project.settings(
  libraryDependencies += "org.scalameta" %% "scalameta" % "1.8.0" % Provided,
  macroAnnotationSettings
  // ... your other project settings
)
lazy val projectThatUsesMacroAnnotations = project.settings(
  macroAnnotationSettings,
  // ... your other project settings
)
```

Additionally, this PR:

* Upgrades joda-convert library.
* Bumps sbt-dependency version (including its settings in the defaultSettings).
* Disables sbt-coursier as a plugin enabled by default.
* Releases `0.7.2`.