### PR TITLE
Bump circe to 0.9.0-M1

### DIFF
--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -43,7 +43,7 @@ object libraries {
     "catbird"                  -> "0.18.0",
     "cats"                     -> "0.9.0",
     "cats-effect"              -> "0.4",
-    "circe"                    -> "0.8.0",
+    "circe"                    -> "0.9.0-M1",
     "config"                   -> "1.3.1",
     "coursier"                 -> "1.0.0-RC11",
     "discipline"               -> "0.8",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.3-SNAPSHOT"
+version in ThisBuild := "0.7.3"


### PR DESCRIPTION
so there are no conflicts regarding the cats version in github4s