### PR TITLE
Add sbt plugin ModuleID lookup for `%` and `%%`

### DIFF
--- a/src/main/scala-2.10/sbtorgpolicies/settings/ScalaSettings.scala
+++ b/src/main/scala-2.10/sbtorgpolicies/settings/ScalaSettings.scala
@@ -27,6 +27,12 @@ trait ScalaSettings { self: dependencies =>
   def %(artifactId: String, version: String): ModuleID =
     getLib(artifactId, Some(version)).toModuleId.cross(CrossVersion.Disabled)
 
+  def %(artifactId: String, isSbtPlugin: Boolean): ModuleID =
+    getLib(artifactId, isSbtPlugin = isSbtPlugin).toModuleId.cross(CrossVersion.Disabled)
+
+  def %(artifactId: String, version: String, isSbtPlugin: Boolean): ModuleID =
+    getLib(artifactId, Some(version), isSbtPlugin).toModuleId.cross(CrossVersion.Disabled)
+
   /**
    * It allows alternative Scala organization, however, scala-lang is still used
    * during transitive ivy resolution and should be added.

--- a/src/main/scala-2.12/sbtorgpolicies/settings/ScalaSettings.scala
+++ b/src/main/scala-2.12/sbtorgpolicies/settings/ScalaSettings.scala
@@ -27,6 +27,12 @@ trait ScalaSettings { self: dependencies =>
   def %(artifactId: String, version: String): ModuleID =
     getLib(artifactId, Some(version)).toModuleId.withCrossVersion(sbt.librarymanagement.Disabled())
 
+  def %(artifactId: String, isSbtPlugin: Boolean): ModuleID =
+    getLib(artifactId, isSbtPlugin = isSbtPlugin).toModuleId.withCrossVersion(sbt.librarymanagement.Disabled())
+
+  def %(artifactId: String, version: String, isSbtPlugin: Boolean): ModuleID =
+    getLib(artifactId, Some(version), isSbtPlugin).toModuleId.withCrossVersion(sbt.librarymanagement.Disabled())
+
   /**
    * It allows alternative Scala organization, however, scala-lang is still used
    * during transitive ivy resolution and should be added.

--- a/src/main/scala/sbtorgpolicies/settings/dependencies.scala
+++ b/src/main/scala/sbtorgpolicies/settings/dependencies.scala
@@ -39,6 +39,12 @@ trait dependencies extends ScalaSettings {
   def %%(artifactId: String, version: String): ModuleID =
     getLib(artifactId, Some(version)).toModuleId
 
+  def %%(artifactId: String, isSbtPlugin: Boolean): ModuleID =
+    getLib(artifactId, isSbtPlugin = isSbtPlugin).toModuleId
+
+  def %%(artifactId: String, version: String, isSbtPlugin: Boolean): ModuleID =
+    getLib(artifactId, Some(version), isSbtPlugin).toModuleId
+
   def %%%(artifactId: String): ModuleID =
     getLib(artifactId).toJsModuleId
 
@@ -54,8 +60,8 @@ trait dependencies extends ScalaSettings {
 
   }
 
-  protected[this] def getLib(lib: String, maybeVersion: Option[String] = None): Dep = {
-    val artifact: (String, String, String) = libs(lib)
+  protected[this] def getLib(lib: String, maybeVersion: Option[String] = None, isSbtPlugin: Boolean = false): Dep = {
+    val artifact: (String, String, String) = (if (isSbtPlugin) allPlugins else libs)(lib)
     val dep                                = Dep(artifact._1, artifact._2, artifact._3)
     maybeVersion.foldLeft(dep)((module, revision) => module.copy(revision = revision))
   }


### PR DESCRIPTION
I couldn't add default parameters to `def %(artifactId: String)` and `def %(artifactId: String, version: String)` because of "multiple overloaded alternatives of method % define default arguments" error.

```scala
addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
```

becomes

```scala
addSbtPlugin(%("sbt-git", true))
```