### PR TITLE
Downgrades to cats 0.9 and github4s 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 10/04/2017 - Version 0.7.7
+
+Release changes:
+
+* Adds grpc to the library Catalogue ([#659](https://github.com/47deg/sbt-org-policies/pull/659))
+
+
+## 10/02/2017 - Version 0.7.6
+
+Release changes:
+
+* Add sbt plugin ModuleID lookup for `%` and `%%` ([#650](https://github.com/47deg/sbt-org-policies/pull/650))
+* Upgrades sbt-microsites plugin and others ([#658](https://github.com/47deg/sbt-org-policies/pull/658))
+
+
 ## 09/22/2017 - Version 0.7.5
 
 Release changes:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 [comment]: # (Start Badges)
 
-[![Build Status](https://travis-ci.org/47deg/sbt-org-policies.svg?branch=master)](https://travis-ci.org/47deg/sbt-org-policies) [![Maven Central](https://img.shields.io/badge/maven%20central-0.7.5-green.svg)](https://repo1.maven.org/maven2/com/47deg/sbt-org-policies_2.12_1.0) [![License](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/47deg/sbt-org-policies/master/LICENSE) [![GitHub Issues](https://img.shields.io/github/issues/47deg/sbt-org-policies.svg)](https://github.com/47deg/sbt-org-policies/issues)
+[![Build Status](https://travis-ci.org/47deg/sbt-org-policies.svg?branch=master)](https://travis-ci.org/47deg/sbt-org-policies) [![Maven Central](https://img.shields.io/badge/maven%20central-0.7.7-green.svg)](https://repo1.maven.org/maven2/com/47deg/sbt-org-policies_2.12_1.0) [![License](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/47deg/sbt-org-policies/master/LICENSE) [![GitHub Issues](https://img.shields.io/github/issues/47deg/sbt-org-policies.svg)](https://github.com/47deg/sbt-org-policies/issues)
 
 [comment]: # (End Badges)
 # sbt-org-policies
@@ -14,7 +14,7 @@
 Add the following line to `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.7.5")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.7.7")
 ```
 
 [comment]: # (End Replace)

--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -31,12 +31,12 @@ object libraries {
   )
 
   protected val vOthers: Map[String, String] = Map[String, String](
-    "akka"                     -> "2.5.5",
+    "akka"                     -> "2.5.6",
     "akka-http"                -> "10.0.10",
     "algebra"                  -> "0.7.0",
     "alleycats"                -> "0.2.0",
     "apache-kafka"             -> "0.11.0.1",
-    "aws-sdk"                  -> "1.11.204",
+    "aws-sdk"                  -> "1.11.207",
     "base64"                   -> "0.2.3",
     "cassandra-driver"         -> "3.3.0",
     "catalysts"                -> "0.0.5",
@@ -54,14 +54,15 @@ object libraries {
     "finch"                    -> "0.15.1",
     "fs2"                      -> "0.9.7",
     "fs2-cats"                 -> "0.4.0",
+    "grpc"                     -> "1.6.1",
     "h2"                       -> "1.4.196",
-    "http4s"                   -> "0.18.0-M1",
+    "http4s"                   -> "0.18.0-M2",
     "joda-convert"             -> "1.9.2",
     "joda-time"                -> "2.9.9",
     "journal"                  -> "3.0.18",
     "jwt-scala"                -> "0.14.0",
     "kind-projector"           -> "0.9.4",
-    "log4s"                    -> "1.3.6",
+    "log4s"                    -> "1.4.0",
     "machinist"                -> "0.6.2",
     "macro-compat"             -> "1.1.1",
     "monix"                    -> "2.3.0",
@@ -96,8 +97,8 @@ object libraries {
     "simulacrum"               -> "0.11.0",
     "slf4j"                    -> "1.7.25",
     "slick"                    -> "3.2.1",
-    "slogging"                 -> "0.5.3",
-    "specs2"                   -> "3.9.5"
+    "slogging"                 -> "0.6.0",
+    "specs2"                   -> "4.0.0"
   )
 
   val vPlugins47: Map[String, String] = Map[String, String](
@@ -236,6 +237,16 @@ object libraries {
     "fs2-io"                 -> (("co.fs2", "fs2-io", v("fs2"))),
     "fs2-cats"               -> (("co.fs2", "fs2-cats", v("fs2-cats"))),
     "github4s"               -> (("com.47deg", "github4s", v("github4s"))),
+    "grpc-all"               -> (("io.grpc", "grpc-all", v("grpc"))),
+    "grpc-auth"              -> (("io.grpc", "grpc-auth", v("grpc"))),
+    "grpc-context"           -> (("io.grpc", "grpc-context", v("grpc"))),
+    "grpc-core"              -> (("io.grpc", "grpc-core", v("grpc"))),
+    "grpc-netty"             -> (("io.grpc", "grpc-netty", v("grpc"))),
+    "grpc-protobuf"          -> (("io.grpc", "grpc-protobuf", v("grpc"))),
+    "grpc-okhttp"            -> (("io.grpc", "grpc-okhttp", v("grpc"))),
+    "grpc-services"          -> (("io.grpc", "grpc-services", v("grpc"))),
+    "grpc-stub"              -> (("io.grpc", "grpc-stub", v("grpc"))),
+    "grpc-testing"           -> (("io.grpc", "grpc-testing", v("grpc"))),
     "http4s-blaze-client"    -> (("org.http4s", "http4s-blaze-client", v("http4s"))),
     "http4s-blaze-server"    -> (("org.http4s", "http4s-blaze-server", v("http4s"))),
     "http4s-circe"           -> (("org.http4s", "http4s-circe", v("http4s"))),

--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -43,6 +43,7 @@ object libraries {
     "catbird"                  -> "0.18.0",
     "cats"                     -> "1.0.0-MF",
     "cats-effect"              -> "0.4",
+    "cats-mtl"                 -> "0.0.2",
     "circe"                    -> "0.9.0-M1",
     "config"                   -> "1.3.1",
     "coursier"                 -> "1.0.0-RC12",
@@ -100,8 +101,8 @@ object libraries {
   )
 
   val vPlugins47: Map[String, String] = Map[String, String](
-    "sbt-dependencies" -> "0.3.1",
-    "sbt-microsites"   -> "0.7.0"
+    "sbt-dependencies" -> "0.3.4",
+    "sbt-microsites"   -> "0.7.3"
   )
 
   val vPluginsOthers: Map[String, String] = Map[String, String](
@@ -185,6 +186,8 @@ object libraries {
     "cats-kernel"            -> (("org.typelevel", "cats-kernel", v("cats"))),
     "cats-laws"              -> (("org.typelevel", "cats-laws", v("cats"))),
     "cats-macros"            -> (("org.typelevel", "cats-macros", v("cats"))),
+    "cats-mtl-core"          -> (("org.typelevel", "cats-mtl-core", v("cats-mtl"))),
+    "cats-testkit"           -> (("org.typelevel", "cats-testkit", v("cats"))),
     "circe-core"             -> (("io.circe", "circe-core", v("circe"))),
     "circe-generic"          -> (("io.circe", "circe-generic", v("circe"))),
     "circe-parser"           -> (("io.circe", "circe-parser", v("circe"))),

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -52,14 +52,14 @@ object ProjectPlugin extends AutoPlugin {
       addSbtPlugin("org.scala-js"       % "sbt-scalajs"            % "0.6.20"),
       addSbtPlugin("de.heikoseeberger"  % "sbt-header"             % "3.0.1"),
       addSbtPlugin("com.47deg"          % "sbt-dependencies"       % "0.3.1"),
-      addSbtPlugin("com.47deg"          % "sbt-microsites"         % "0.7.0"),
+      addSbtPlugin("com.47deg"          % "sbt-microsites"         % "0.7.3"),
       libraryDependencies ++= {
         val sbtBinaryVersionValue = (sbtBinaryVersion in pluginCrossBuild).value
 
         val scalaBinaryVersionValue = (scalaBinaryVersion in update).value
 
         val (tutPluginVersion, sbtScalafmtVersion) = sbtBinaryVersionValue match {
-          case "0.13" => ("0.5.3", "0.6.8")
+          case "0.13" => ("0.5.5", "0.6.8")
           case "1.0"  => ("0.6.1", "1.2.0")
         }
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -52,8 +52,7 @@ object ProjectPlugin extends AutoPlugin {
       addSbtPlugin("org.scala-js"       % "sbt-scalajs"            % "0.6.20"),
       addSbtPlugin("de.heikoseeberger"  % "sbt-header"             % "3.0.1"),
       addSbtPlugin("com.47deg"          % "sbt-dependencies"       % "0.3.1"),
-      // addSbtPlugin("com.lucidchart"     % "sbt-scalafmt"  % "1.10"),
-      // addSbtPlugin("com.geirsson"       % "sbt-scalafmt"  % "1.2.0"),
+      addSbtPlugin("com.47deg"          % "sbt-microsites"         % "0.7.0"),
       libraryDependencies ++= {
         val sbtBinaryVersionValue = (sbtBinaryVersion in pluginCrossBuild).value
 
@@ -84,8 +83,7 @@ object ProjectPlugin extends AutoPlugin {
             "-Dplugin.version=" + version.value,
             "-Dscala.version=" + scalaVersion.value
           )
-      },
-      addSbtPlugin("com.47deg" % "sbt-microsites" % "0.7.0")
+      }
     )
 
     lazy val coreSettings: Seq[Def.Setting[_]] = commonSettings ++ Seq(
@@ -98,8 +96,8 @@ object ProjectPlugin extends AutoPlugin {
         }
       },
       libraryDependencies ++= Seq(
-        %%("github4s"),
-        %%("cats-core"),
+        %%("github4s", "0.15.0"),
+        %%("cats-core", "0.9.0"),
         %%("base64"),
         %%("moultingyaml"),
         %%("scalatest")             % Test,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.6"
+version in ThisBuild := "0.7.8-SNAPSHOT"


### PR DESCRIPTION
For https://github.com/47deg/sbt-org-policies/pull/654, so forward progress can be made for the eventual `sbt-freestyle` version bump.

Includes merge from master