### PR TITLE
sbt-compat is not exposed by the plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: scala
 
 matrix:
   include:
-    - scala: 2.12.3
+    - scala: 2.12.4
       jdk: oraclejdk8
       env:
-        - SBT_VERSION=1.0.1
+        - SBT_VERSION=1.0.2
     - scala: 2.10.6
       jdk: oraclejdk8
       env:
@@ -33,7 +33,7 @@ after_success:
       if grep -q "SNAPSHOT" version.sbt; then
         sbt ^^$SBT_VERSION publish;
       else
-        if [ "$SBT_VERSION" = "1.0.1" ]; then
+        if [ "$SBT_VERSION" = "1.0.2" ]; then
           sbt ^^$SBT_VERSION orgUpdateDocFiles;
           git reset --hard HEAD;
           git clean -f;

--- a/autocheck/build.sbt
+++ b/autocheck/build.sbt
@@ -12,8 +12,8 @@ lazy val `org-policies-auto-dep-check` = (project in file("."))
   .settings(name := "org-policies-auto-dep-check")
   .settings(noPublishSettings: _*)
   .settings(Seq(
-    scalaVersion := "2.12.3",
-    crossScalaVersions := Seq("2.12.3"),
+    scalaVersion := "2.12.4",
+    crossScalaVersions := Seq("2.12.4"),
     scalaOrganization := "org.scala-lang",
     orgGithubSetting := GitHubSettings(
       organization = "47deg",

--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -25,6 +25,7 @@ object libraries {
     "case-classy"   -> "0.4.0",
     "fetch"         -> "0.7.0",
     "freestyle"     -> "0.4.0",
+    "frees-rpc"     -> "0.1.0",
     "github4s"      -> "0.16.0",
     "org-policies"  -> sbtorgpolicies.BuildInfo.version,
     "scheckToolbox" -> "0.2.2"
@@ -229,6 +230,7 @@ object libraries {
     "frees-http-play"        -> (("io.frees", "frees-http-play", v("freestyle"))),
     "frees-logging"          -> (("io.frees", "frees-logging", v("freestyle"))),
     "frees-monix"            -> (("io.frees", "frees-monix", v("freestyle"))),
+    "frees-rpc"              -> (("io.frees", "frees-rpc", v("frees-rpc"))),
     "frees-slick"            -> (("io.frees", "frees-slick", v("freestyle"))),
     "frees-tagless"          -> (("io.frees", "frees-tagless", v("freestyle"))),
     "frees-twitter-util"     -> (("io.frees", "frees-twitter-util", v("freestyle"))),

--- a/core/src/main/scala/sbtorgpolicies/model.scala
+++ b/core/src/main/scala/sbtorgpolicies/model.scala
@@ -117,7 +117,7 @@ object model {
 
   object sbtV {
     val `0.13`: String = "0.13.16"
-    val `1.0`: String  = "1.0.1"
+    val `1.0`: String  = "1.0.2"
 
     val crossSbtVersions: List[String] = List(`0.13`, `1.0`)
   }
@@ -126,8 +126,8 @@ object model {
 
     val `2.10`: String = "2.10.6"
     val `2.11`: String = "2.11.11"
-    val `2.12`: String = "2.12.3"
-    val `2.13`: String = "2.13.0-M1"
+    val `2.12`: String = "2.12.4"
+    val `2.13`: String = "2.13.0-M2"
 
     val latestScalaVersion: String = `2.12`
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -23,16 +23,7 @@ object ProjectPlugin extends AutoPlugin {
       organization := "com.47deg",
       organizationName := "47 Degrees",
       organizationHomepage := Some(url("http://47deg.com")),
-      crossScalaVersions := Seq(scalac.`2.12`),
-      resolvers += Resolver.url("dwijnand-sbt-plugins", url("https://dl.bintray.com/dwijnand/sbt-plugins/"))(
-        Resolver.ivyStylePatterns),
-      libraryDependencies += {
-        Defaults.sbtPluginExtra(
-          "com.dwijnand" % "sbt-compat" % "1.0.0",
-          (sbtBinaryVersion in pluginCrossBuild).value,
-          (scalaBinaryVersion in update).value
-        )
-      }
+      crossScalaVersions := Seq(scalac.`2.12`)
     )
 
     lazy val pluginSettings: Seq[Def.Setting[_]] = commonSettings ++ Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 import sbt.Resolver.sonatypeRepo
 
 resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases"))
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.0")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.2")

--- a/src/sbt-test/sbtorgpolicies/valid-files/.travis.yml
+++ b/src/sbt-test/sbtorgpolicies/valid-files/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
 - 2.11.11
-- 2.12.3
+- 2.12.4
 
 jdk:
 - oraclejdk8

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.3-SNAPSHOT"
+version in ThisBuild := "0.8.3"


### PR DESCRIPTION
Fixes #689 

It also: 
* Bumps Scala to `2.12.14` and sbt to `1.0.2`
* Adds `frees-rpc` to the catalog.
* Releases new patch version.