### PR TITLE
Fixes a compatibility issue with FileReader and FileWriter

### DIFF
--- a/core/src/main/scala/sbtorgpolicies/io/FileReader.scala
+++ b/core/src/main/scala/sbtorgpolicies/io/FileReader.scala
@@ -24,7 +24,7 @@ import sbtorgpolicies.io.syntax._
 
 import scala.annotation.tailrec
 
-trait FileReader {
+class FileReader {
 
   def exists(path: String): Boolean =
     Either

--- a/core/src/main/scala/sbtorgpolicies/io/FileWriter.scala
+++ b/core/src/main/scala/sbtorgpolicies/io/FileWriter.scala
@@ -30,7 +30,7 @@ import cats.syntax.traverse._
 import sbtorgpolicies.exceptions._
 import sbtorgpolicies.io.syntax._
 
-trait FileWriter {
+class FileWriter {
 
   def writeContentToFile(content: String, output: String): IOResult[Unit] = {
 

--- a/core/src/main/scala/sbtorgpolicies/rules/YamlOps.scala
+++ b/core/src/main/scala/sbtorgpolicies/rules/YamlOps.scala
@@ -21,7 +21,7 @@ import net.jcazevedo.moultingyaml._
 import sbtorgpolicies.exceptions.YamlException
 import sbtorgpolicies.rules.syntax._
 
-trait YamlOps {
+class YamlOps {
 
   def parseContent(str: String): YamlResult[YamlObject] =
     Either

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.8.12-SNAPSHOT"
+version in ThisBuild := "0.8.12"


### PR DESCRIPTION
Breaks compatibility with plugins using `new FileReader`, hard to solve with cyclic dependencies like in sbt-microsites, where it depends on a previous version of itself.

Also releases the new version