### PR TITLE
Revert Scalameta version in master version list to 1.8.0, and exclude from dependency updates

### DIFF
--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -94,7 +94,7 @@ object libraries {
     "scalactic"                -> "3.0.5",
     "scalaj"                   -> "2.3.0",
     "scalameta"                -> "3.4.0",
-    "scalameta-paradise"       -> "3.0.0-M10",
+    "scalameta-paradise"       -> "3.0.0-M11",
     "scalamock"                -> "3.6.0",
     "scalatags"                -> "0.6.7",
     "scalatest"                -> "3.0.5",

--- a/core/src/main/scala/sbtorgpolicies/libraries.scala
+++ b/core/src/main/scala/sbtorgpolicies/libraries.scala
@@ -93,7 +93,7 @@ object libraries {
     "scheckShapeless"          -> "1.1.8",
     "scalactic"                -> "3.0.5",
     "scalaj"                   -> "2.3.0",
-    "scalameta"                -> "3.4.0",
+    "scalameta"                -> "1.8.0", // we keep scalameta at 1.8.0 until we eventually get rid of it
     "scalameta-paradise"       -> "3.0.0-M11",
     "scalamock"                -> "3.6.0",
     "scalatags"                -> "0.6.7",

--- a/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
@@ -122,7 +122,7 @@ trait AllSettings
 
   lazy val scalaMetaSettings = Seq(
     addCompilerPlugin(%%("scalameta-paradise") cross CrossVersion.full),
-    libraryDependencies += %%("scalameta", "1.8.0"),
+    libraryDependencies += %%("scalameta"),
     scalacOptions += "-Xplugin-require:macroparadise",
     scalacOptions in (Compile, console) ~= (_ filterNot (_ contains "paradise")) // macroparadise plugin doesn't work in repl yet.
   )

--- a/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
@@ -16,6 +16,7 @@
 
 package sbtorgpolicies.settings
 
+import com.timushev.sbt.updates.UpdatesPlugin.autoImport._
 import com.typesafe.sbt.pgp.PgpKeys
 import com.typesafe.sbt.pgp.PgpKeys._
 import dependencies.DependenciesPlugin
@@ -123,6 +124,7 @@ trait AllSettings
   lazy val scalaMetaSettings = Seq(
     addCompilerPlugin(%%("scalameta-paradise") cross CrossVersion.full),
     libraryDependencies += %%("scalameta"),
+    dependencyUpdatesFilter -= moduleFilter(name = "scalameta"), // we keep scalameta at 1.8.0 until we eventually get rid of it
     scalacOptions += "-Xplugin-require:macroparadise",
     scalacOptions in (Compile, console) ~= (_ filterNot (_ contains "paradise")) // macroparadise plugin doesn't work in repl yet.
   )


### PR DESCRIPTION
Also bumps `scalameta-paradise` version.