### PR TITLE
 Exclude scalameta from project's own dependency checker

### DIFF
--- a/autocheck/build.sbt
+++ b/autocheck/build.sbt
@@ -26,7 +26,8 @@ lazy val `org-policies-auto-dep-check` = (project in file("."))
     resolvers ++= Seq(Resolver.sonatypeRepo("snapshots"), Resolver.bintrayIvyRepo("sbt", "sbt-plugin-releases")),
     libraryDependencies ++=
       scalaLibs
-        .filter(_._1 != "scalameta-paradise")
+        //TODO: remove monix exclusion once they release 3.0 or sbt-dependency-updates figures out how to ignore dev snapshots
+        .filterNot { case(depName, _) => depName.startsWith("scalameta") || depName.startsWith("monix") }
         .mapValues(lib => lib._1 %% lib._2 % lib._3)
         .values
         .toList ++

--- a/autocheck/build.sbt
+++ b/autocheck/build.sbt
@@ -26,7 +26,8 @@ lazy val `org-policies-auto-dep-check` = (project in file("."))
     resolvers ++= Seq(Resolver.sonatypeRepo("snapshots"), Resolver.bintrayIvyRepo("sbt", "sbt-plugin-releases")),
     libraryDependencies ++=
       scalaLibs
-        //TODO: remove monix exclusion once they release 3.0 or sbt-dependency-updates figures out how to ignore dev snapshots
+        //TODO: remove monix exclusion once they release 3.0 or sbt-updates figures out how to ignore dev snapshots.
+        //  See https://mvnrepository.com/artifact/io.monix/monix, https://github.com/rtimush/sbt-updates/issues/19
         .filterNot { case(depName, _) => depName.startsWith("scalameta") || depName.startsWith("monix") }
         .mapValues(lib => lib._1 %% lib._2 % lib._3)
         .values

--- a/autocheck/project/build.properties
+++ b/autocheck/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.3
+sbt.version = 1.1.1

--- a/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
@@ -124,7 +124,7 @@ trait AllSettings
   lazy val scalaMetaSettings = Seq(
     addCompilerPlugin(%%("scalameta-paradise") cross CrossVersion.full),
     libraryDependencies += %%("scalameta"),
-    dependencyUpdatesFilter -= moduleFilter(name = "scalameta"), // we keep scalameta at 1.8.0 until we eventually get rid of it
+    dependencyUpdatesFilter -= moduleFilter(name = "scalameta*"), // we keep scalameta at 1.8.0 until we eventually get rid of it
     scalacOptions += "-Xplugin-require:macroparadise",
     scalacOptions in (Compile, console) ~= (_ filterNot (_ contains "paradise")) // macroparadise plugin doesn't work in repl yet.
   )


### PR DESCRIPTION
#1008 excluded scalameta from dependency checks provided to clients in `scalametaSettings`, this patch excludes it from `sbt-org-policies`'s own checker. Also excludes Monix until the dependency checker can make sense of it.

Also adds a missing wildcard to the scalameta dependency check in `scalametaSettings`, to include related projects.