### PR TITLE
Update Scala versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 matrix:
   include:
-    - scala: 2.12.4
+    - scala: 2.12.6
       jdk: oraclejdk8
       env:
         - SBT_VERSION=1.1.1

--- a/core/src/main/scala/sbtorgpolicies/model.scala
+++ b/core/src/main/scala/sbtorgpolicies/model.scala
@@ -126,8 +126,8 @@ object model {
 
     val `2.10`: String = "2.10.7"
     val `2.11`: String = "2.11.12"
-    val `2.12`: String = "2.12.4"
-    val `2.13`: String = "2.13.0-M2"
+    val `2.12`: String = "2.12.6"
+    val `2.13`: String = "2.13.0-M4"
 
     val latestScalaVersion: String = `2.12`
 

--- a/src/sbt-test/sbtorgpolicies/valid-files/.travis.yml
+++ b/src/sbt-test/sbtorgpolicies/valid-files/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
 - 2.11.12
-- 2.12.4
+- 2.12.6
 
 jdk:
 - oraclejdk8

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.9.2-SNAPSHOT"
+version in ThisBuild := "0.9.2"


### PR DESCRIPTION
Updated to the latest Scala versions and removed the SNAPSHOT in version.sbt
Fixes #1031 

It also updates the .travis.yml with the new Scala versions