### PR TITLE
Updated plugins.sbt file to "0.9.2" sbt-org-policies version

### DIFF
--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -92,7 +92,7 @@ object ProjectPlugin extends AutoPlugin {
         %%("base64"),
         %%("moultingyaml"),
         %%("scalatest")             % Test,
-        %%("scalacheck")            % Test,
+        %%("scalacheck", "1.13.4")  % Test,
         %%("scheckToolboxDatetime") % Test,
         %%("scalamockScalatest")    % Test
       ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 import sbt.Resolver.sonatypeRepo
 resolvers ++= Seq(sonatypeRepo("snapshots"), sonatypeRepo("releases"))
-addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.8.26")
+addSbtPlugin("com.47deg" % "sbt-org-policies" % "0.9.2")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")


### PR DESCRIPTION
This PR updates `plugins.sbt` file to the latest `sbt-org-policies` version. In this case to the "0.9.2"