### PR TITLE
Fixes a bug when the replaceable string contains a dollar sign

### DIFF
--- a/core/src/main/scala/sbtorgpolicies/github/GitHubOps.scala
+++ b/core/src/main/scala/sbtorgpolicies/github/GitHubOps.scala
@@ -177,8 +177,8 @@ class GitHubOps(owner: String, repo: String, accessToken: Option[String], fileRe
       message: String,
       baseDir: File,
       dirToCommit: File,
-      blobConfig: BlobConfig = defaultBlobConfig,
-      commitSha: Option[String] = None): Github4sResponse[RefCommit] = {
+      blobConfig: BlobConfig,
+      commitSha: Option[String]): Github4sResponse[RefCommit] = {
 
     def fetchBaseTreeSha: Github4sResponse[Option[RefCommit]] =
       commitSha map { sha =>

--- a/core/src/test/scala/sbtorgpolicies/templates/TemplatesEngineTest.scala
+++ b/core/src/test/scala/sbtorgpolicies/templates/TemplatesEngineTest.scala
@@ -70,13 +70,15 @@ class TemplatesEngineTest extends TestOps {
         |<{{organizationHomePage}}>
         |
         |{{contributors}}
+        |{{special}}
       """.stripMargin.replace("\r", "")
 
     val replacements = Map(
       "year"                 -> 2017.asReplaceable,
       "organizationName"     -> "47 Degrees".asReplaceable,
       "organizationHomePage" -> "http://www.47deg.com".asReplaceable,
-      "contributors"         -> List("47 Deg", "Developers").asReplaceable
+      "contributors"         -> List("47 Deg", "Developers").asReplaceable,
+      "special"              -> "special char \\$".asReplaceable
     )
 
     val expectedContent = originalContent
@@ -87,8 +89,11 @@ class TemplatesEngineTest extends TestOps {
         "{{contributors}}",
         """* 47 Deg
           |* Developers""".stripMargin.replace("\r", ""))
+      .replace("{{special}}", "special char $")
 
     val result = templatesEngine.replaceWith(originalContent, replacements)
+
+    result.leftMap(_.printStackTrace())
 
     result.isRight shouldBe true
     result.right.get shouldBe expectedContent


### PR DESCRIPTION
While trying to deploy `mu`, we found that if a PR contains a dollar sign, the template engine was failing.

I've reproduced the error. The problem is that the dollar sign is interpreted by the `replaceAll` method as a substitution of a group, a group that doesn't exist in the regex used:

```scala
private[this] def replacementPattern(key: String): Regex = s"\\{\\{$key\\}\\}".r
```