### PR TITLE
Don't set -Yno-adapted-args in Scala 2.13

### DIFF
--- a/core/src/main/scala/sbtorgpolicies/model.scala
+++ b/core/src/main/scala/sbtorgpolicies/model.scala
@@ -71,16 +71,24 @@ object model {
     "-Xplugin-require:macroparadise")
 
   /** Scalac strict compilation options.*/
-  lazy val scalacStrictOptions = Seq(
-    "-Yno-adapted-args",
-    "-Ywarn-dead-code",
-    "-Ywarn-numeric-widen",
-    "-Ywarn-value-discard",
-    "-Xfuture"
-  )
+  def scalacStrictOptions(scalaVersion: String) = {
+    val noAdaptedArgs = if (scalaVersion >= "2.13.0") {
+      Seq()
+    } else {
+      Seq("-Yno-adapted-args")
+    }
+
+    Seq(
+      "-Ywarn-dead-code",
+      "-Ywarn-numeric-widen",
+      "-Ywarn-value-discard",
+      "-Xfuture"
+    ) ++ noAdaptedArgs
+  }
 
   /** Combines all scalac options.*/
-  lazy val scalacAllOptions: Seq[String] = scalacCommonOptions ++ scalacLanguageOptions ++ scalacStrictOptions
+  def scalacAllOptions(scalaVersion: String): Seq[String] =
+    scalacCommonOptions ++ scalacLanguageOptions ++ scalacStrictOptions(scalaVersion)
 
   /** Github settings and related settings usually found in a Github README.*/
   case class GitHubSettings(

--- a/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
@@ -153,7 +153,7 @@ trait AllSettings
     scalaOrganization := "org.scala-lang",
     scalaVersion := scalac.`2.12`,
     crossScalaVersions := scalac.crossScalaVersions,
-    scalacOptions ++= scalacAllOptions
+    scalacOptions ++= scalacAllOptions(scalaVersion.value)
   )
 
   implicit val settingAppender: sbt.Append.Value[Seq[(String, java.net.URL)], License] =


### PR DESCRIPTION
Scala 2.13 no longer allows the option `-Yno-adapted-args`