### PR TITLE
Fix Multiple resolvers warning

### DIFF
--- a/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
@@ -50,11 +50,7 @@ trait AllSettings
    * Adds Sonatype release repository and "withCachedResolution" to the update options
    */
   lazy val sharedCommonSettings = Seq(
-    resolvers ++= Seq(
-      Resolver.sonatypeRepo("releases"),
-      Resolver.typesafeIvyRepo("releases"),
-      Resolver.bintrayRepo("beyondthelines", "maven")
-    ),
+    resolvers ++= Seq(Resolver.sonatypeRepo("releases")),
     updateOptions := updateOptions.value.withCachedResolution(true)
   )
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12.0-SNAPSHOT"
+version in ThisBuild := "0.12.0-M3"


### PR DESCRIPTION
With sbt 1.3.0, we are seeing some warnings like this one:

```
[warn] Multiple resolvers having different access mechanism configured with same name 'typesafe-ivy-releases'. To avoid conflict, Remove duplicate project resolvers (`resolvers`) or rename publishing resolver (`publishTo`).
```

This PR/new release should fix it.