### PR TITLE
Turn off annoying "unused import" warnings in console

### DIFF
--- a/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
@@ -149,7 +149,8 @@ trait AllSettings
     scalaOrganization := "org.scala-lang",
     scalaVersion := scalac.`2.12`,
     crossScalaVersions := scalac.crossScalaVersions,
-    scalacOptions ++= scalacAllOptions(scalaVersion.value)
+    scalacOptions ++= scalacAllOptions(scalaVersion.value),
+    Compile / console / scalacOptions -= "-Xlint"
   )
 
   implicit val settingAppender: sbt.Append.Value[Seq[(String, java.net.URL)], License] =


### PR DESCRIPTION
Before:

```
scala> import scala.math._
<console>:11: warning: Unused import
       import scala.math._
                         ^
import scala.math._

scala>
```

After:

```
scala> import scala.math._
import scala.math._

scala>
```