### PR TITLE
Fix the does-this-tag-already-exist logic

### DIFF
--- a/core/src/test/scala/sbtorgpolicies/TestOps.scala
+++ b/core/src/test/scala/sbtorgpolicies/TestOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/sbtorgpolicies/TestOps.scala
+++ b/core/src/test/scala/sbtorgpolicies/TestOps.scala
@@ -18,7 +18,7 @@ package sbtorgpolicies
 
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{FunSuite, Matchers}
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
 import scala.language.implicitConversions
 

--- a/core/src/test/scala/sbtorgpolicies/arbitraries/ExceptionArbitraries.scala
+++ b/core/src/test/scala/sbtorgpolicies/arbitraries/ExceptionArbitraries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/sbtorgpolicies/arbitraries/GitHubArbitraries.scala
+++ b/core/src/test/scala/sbtorgpolicies/arbitraries/GitHubArbitraries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/sbtorgpolicies/arbitraries/TemplateArbitraries.scala
+++ b/core/src/test/scala/sbtorgpolicies/arbitraries/TemplateArbitraries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/sbtorgpolicies/arbitraries/badgeArbitraries.scala
+++ b/core/src/test/scala/sbtorgpolicies/arbitraries/badgeArbitraries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/sbtorgpolicies/arbitraries/modelArbitratries.scala
+++ b/core/src/test/scala/sbtorgpolicies/arbitraries/modelArbitratries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/sbtorgpolicies/github/GitHubOpsTest.scala
+++ b/core/src/test/scala/sbtorgpolicies/github/GitHubOpsTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/sbtorgpolicies/rules/FileValidationTest.scala
+++ b/core/src/test/scala/sbtorgpolicies/rules/FileValidationTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/sbtorgpolicies/rules/RulesTest.scala
+++ b/core/src/test/scala/sbtorgpolicies/rules/RulesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/sbtorgpolicies/templates/TemplatesEngineTest.scala
+++ b/core/src/test/scala/sbtorgpolicies/templates/TemplatesEngineTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2017-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
It was accidentally matching on other tags that start with the name of the tag we are trying to release.

Also:
* Update some more copyright headers
* Fix a deprecation warning in the tests