### PR TITLE
Release v0.12.0.1

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12.0"
+version in ThisBuild := "0.12.0.1"


### PR DESCRIPTION
This is not a prefix of any previously released version number, to work around the bug fixed by https://github.com/47deg/sbt-org-policies/pull/1233