### PR TITLE
Release v0.12.1

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12.0.2-SNAPSHOT"
+version in ThisBuild := "0.12.1"


### PR DESCRIPTION
Yesterday's release of v0.12.0.1 appeared to work (looking at the Travis logs), but failed to show up in Maven Central. My theory is that Central rejects version numbers that don't match the x.y.z format.