### PR TITLE
Stop incorrectly setting the gpg command to "."

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import sbt.Keys._
+import com.jsuereth.sbtpgp.PgpKeys.gpgCommand
 
 lazy val `sbt-org-policies` = (project in file("."))
   .enablePlugins(SbtPlugin)
@@ -19,6 +20,7 @@ lazy val `org-policies-core` = (project in file("core"))
 pgpPassphrase := Some(Option(System.getenv().get("PGP_PASSPHRASE")).getOrElse("").toCharArray)
 pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
 pgpSecretRing := file(s"$gpgFolder/secring.gpg")
+Global / gpgCommand := "gpg"
 
 ThisBuild / parallelExecution := false
 Global / cancelable := true

--- a/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
+++ b/src/main/scala/sbtorgpolicies/settings/AllSettings.scala
@@ -107,7 +107,6 @@ trait AllSettings
    */
   lazy val pgpSettings = Seq(
     pgpPassphrase := Some(getEnvVar("PGP_PASSPHRASE").getOrElse("").toCharArray),
-    gpgCommand := gpgFolder,
     pgpPublicRing := file(s"$gpgFolder/pubring.gpg"),
     pgpSecretRing := file(s"$gpgFolder/secring.gpg")
   )


### PR DESCRIPTION
I guess the behaviour of this setting changed in sbt-pgp 2.x