### PR TITLE
Set the PGP signing key

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ pgpPassphrase := Some(Option(System.getenv().get("PGP_PASSPHRASE")).getOrElse(""
 pgpPublicRing := file(s"$gpgFolder/pubring.gpg")
 pgpSecretRing := file(s"$gpgFolder/secring.gpg")
 Global / gpgCommand := "gpg"
+usePgpKeyHex("99E76A8A1D1E27FF")
 
 ThisBuild / parallelExecution := false
 Global / cancelable := true


### PR DESCRIPTION
We'll need to do this in all projects that use sbt-org-policies.

It looks like we can either set the key this way, or install it into the gpg keyring during `before_install` in Travis. I think I prefer doing it this way.

The key ID was discovered using `gpg --list-packets pubring.gpg`.